### PR TITLE
How does a DNS lookup work

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -214,7 +214,7 @@ DNS lookup
 
 ARP process
 -----------
-In order to send an ARP broadcast the network stack lbirary needs the target IP
+In order to send an ARP broadcast the network stack library needs the target IP
 address to look up. It also needs to know the MAC address of the interface it
 will use to send out the ARP broadcast.
 

--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,9 @@ The following sections explains all about the physical keyboard
 and the OS interrupts. But, a whole lot happens after that which
 isn't explained. When you just press "g" the browser receives the
 event and the entire auto-complete machinery kicks into high gear.
-Depending on your browser's algorithm and if you are in 
+Depending on your browser's algorithm and if you are in
 private/incognito mode or not various suggestions will be presented
-to you in the dropbox below the URL bar. Most of these algorithms 
+to you in the dropbox below the URL bar. Most of these algorithms
 prioritize results based on search history and bookmarks. Some
 browsers like Rockmelt even suggested your Facebook friends. You are
 going to type "google.com" so none of it matters, but a lot of code

--- a/README.rst
+++ b/README.rst
@@ -41,15 +41,15 @@ connection, but historically has been over PS/2 or ADB connections.
 - The keycode generated is stored by internal keyboard circuitry memory in a
   register called "endpoint".
 
-- The host USB contoller polls that "endpoint" every ~10ms (minimum value
+- The host USB controller polls that "endpoint" every ~10ms (minimum value
   declared by the keyboard), so it gets the keycode value stored on it.
 
 - This value goes to the USB SIE (Serial Interface Engine) to be converted in
   one or more USB packets that follows the low level USB protocol.
 
-- Those packets are sent by a diferential electrical signal over D+ and D- pins
+- Those packets are sent by a differential electrical signal over D+ and D- pins
   (the middle 2) at a maximum speed of 1.5 Mb/s, as an HID
-  (Human Interface Devide) device is always declared to be a "low speed device"
+  (Human Interface Device) device is always declared to be a "low speed device"
   (USB 2.0 compliance).
 
 - This serial signal is then decoded at the computer's host USB controller, and
@@ -146,13 +146,13 @@ Is it a URL or a search term?
 Parse URL
 ---------
 
-* The browser knows what to do based on the iformation provided by the URL,
+* The browser knows what to do based on the information provided by the URL,
   where:
 
   *``http://www.google.com``*
 
   - ``http://``
-    Tells the browser that it needs to communicate using the 'Hiper Text
+    Tells the browser that it needs to communicate using the 'Hyper Text
     Trasnfer Protocol' with the target machine.
 
   - ``www``
@@ -515,11 +515,11 @@ GPU Rendering
 -------------
 
 * During rendering process the graphical computing layers can use general
-  purpose ``CPU`` or the grhapical processor ``GPU`` as well.
+  purpose ``CPU`` or the graphical processor ``GPU`` as well.
 
 * When using ``GPU`` for graphical rendering computations the graphical
-  software layers split the task into multple pieces, so it can take advantage
-  of ``GPU`` massive parallelism for float point calculations requiered for
+  software layers split the task into multiple pieces, so it can take advantage
+  of ``GPU`` massive parallelism for float point calculations required for
   the rendering process.
 
 

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,17 @@ Table of Contents
    :backlinks: none
    :local:
 
+The "g" key is pressed
+----------------------
+The following sections explains all about the physical keyboard and the OS interrupts.
+But, a whole lot happens before that. When you just press "g" the
+browser receives the event and the entire auto-complete machinery kicks into high gear.
+Depending on your browser's algorithm and if you are in private/incognito mode or not
+various suggestions will be presented to you in the dropbox below the URL bar. Some
+browsers like Rockmelt R.I.P even suggested your Facebook friends. You are going to
+type "google.com" so none of it matters, but a lot of code will run before you get
+there and the suggestions will be refined with each key press.
+
 The "enter" key bottoms out
 ---------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -478,11 +478,11 @@ The most common HTTPD servers are Apache for Linux, and IIS for windows.
 * The server will use PHP to interpret the index file, and catch the output.
 * The server will return the output, on the same request to the client.
 
-Behind the scenes of Browser
+Behind the scenes of the Browser
 ----------------------------------
 
 Once the server supplies the resources (HTML, CSS, JS, Image, etc.,)
-to browser it undergoes the below process
+to the browser it undergoes the below process:
 
 * Parsing - HTML, CSS, JS
 * Rendering - Construct DOM Tree → Render Tree → Layout of Render Tree →

--- a/README.rst
+++ b/README.rst
@@ -252,8 +252,7 @@ HTTP Server Request Handle
 --------------------------
 The HTTPD (HTTP Daemon) server is the one handling the requests/responses on
 the server side.
-The HTTPD server can be one of several servers out there, where the most common
-ones are Apache for Linux, and IIS for windows.
+The most HTTPD servers are Apache for Linux, and IIS for windows.
 
 * The HTTPD (HTTP Daemon) receives the request.
 * The server breaks down the request to the following parameters:
@@ -271,10 +270,8 @@ ones are Apache for Linux, and IIS for windows.
   (some cases can override this, but this is the most common method).
 * The server will parse the file according to the handler, for example -
   let's say that Google is running on PHP.
-   * The server will use the PHP executable to interpret the index file,
-     and catch the output.
-   * The server will return the output, back on the same GET request
-     connection to the customer.
+   * The server will use PHP to interpret the index file, and catch the output.
+   * The server will return the output, on the same request to the client.
 
 HTML parsing...
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,8 @@ connection, but historically has been over PS/2 or ADB connections.
   the 'click'.
 
 - Then the mobile OS notify the current focused application of a click event in
-one of its GUI elements (which now is the virtual keyboard application buttons)
+  one of its GUI elements (which now is the virtual keyboard application
+  buttons).
 
 - The virtual keyboard can now rises a software interrupt for sending a
   'key pressed' message back to the OS.

--- a/README.rst
+++ b/README.rst
@@ -481,7 +481,11 @@ HTML parsing
 
 The primary job of HTML parser to parse the HTML markup into a parse tree.
 
-The output tree (the "parse tree") is a tree of DOM element and attribute nodes. DOM is short for Document Object Model. It is the object presentation of the HTML document and the interface of HTML elements to the outside world like JavaScript. The root of the tree is the "Document" object. The DOM has an almost one-to-one relation to the markup.
+The output tree (the "parse tree") is a tree of DOM element and attribute
+nodes. DOM is short for Document Object Model. It is the object presentation
+of the HTML document and the interface of HTML elements to the outside world
+like JavaScript. The root of the tree is the "Document" object. The DOM has
+an almost one-to-one relation to the markup.
 
 **The parsing algorithm**
 
@@ -489,22 +493,33 @@ HTML cannot be parsed using the regular top down or bottom up parsers.
 
 The reasons are:
 * The forgiving nature of the language.
-* The fact that browsers have traditional error tolerance to support well known cases of invalid HTML.
-* The parsing process is reentrant. For other languages, the source doesn't change during parsing, but in HTML, dynamic code (such as script elements containing `document.write()` calls) can add extra tokens, so the parsing process actually modifies the input.
+* The fact that browsers have traditional error tolerance to support well
+known cases of invalid HTML.
+* The parsing process is reentrant. For other languages, the source doesn't
+change during parsing, but in HTML, dynamic code (such as script elements
+containing `document.write()` calls) can add extra tokens, so the parsing
+process actually modifies the input.
 
-Unable to use the regular parsing techniques, browsers create custom parsers for parsing HTML. The parsing algorithm is described in detail by the HTML5 specification.
+Unable to use the regular parsing techniques, browsers create custom
+parsers for parsing HTML. The parsing algorithm is described in
+detail by the HTML5 specification.
 
 The algorithm consists of two stages: tokenization and tree construction.
 
 **Actions when the parsing is finished**
 
-At this stage the browser will mark the document as interactive and start parsing scripts that are in "deferred" mode: those that should be executed after the document is parsed. The document state will be then set to "complete" and a "load" event will be fired.
+At this stage the browser will mark the document as interactive and start
+parsing scripts that are in "deferred" mode: those that should be
+executed after the document is parsed. The document state will be then
+set to "complete" and a "load" event will be fired.
 
-You can see the full algorithms for tokenization and tree construction in the HTML5 specification
+You can see the full algorithms for tokenization and tree construction
+in the HTML5 specification
 
 **Browsers' error tolerance**
 
-You never get an "Invalid Syntax" error on an HTML page. Browsers fix any invalid content and go on.
+You never get an "Invalid Syntax" error on an HTML page. Browsers fix
+any invalid content and go on.
 
 CSS interpretation
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -250,21 +250,31 @@ server name instead of ``google.com``.
 
 HTTP Server Request Handle
 --------------------------
-The HTTPD (HTTP Daemon) server is the one handling the requests/responses on the server side.
-The HTTPD server can be one of many servers out there, where the most common ones are Apache for Linux, and IIS for windows.
+The HTTPD (HTTP Daemon) server is the one handling the requests/responses on
+the server side.
+The HTTPD server can be one of many servers out there, where the most common
+ones are Apache for Linux, and IIS for windows.
 
 * The HTTPD (HTTP Daemon) receives the request.
 * The server breaks down the request to the following parameters:
    * HTTP Request Method (GET, POST, HEAD, PUT and DELETE), in our case - GET.
    * Domain, in our case - google.com.
-   * Requested path/page, in our case - / (as no specific path/page was requested, / is the default path).
-* The server verifies that there is a Virtual Host configured on the server that corresponds with google.com.
+   * Requested path/page, in our case - / (as no specific path/page was
+   requested, / is the default path).
+* The server verifies that there is a Virtual Host configured on the server
+that corresponds with google.com.
 * The server verifies that google.com can accept GET requests.
-* The server verifies that the client is allowed to use this method (by IP, authentication, etc.).
-* The server goes to pull the content that corresponds with the request, in our case it will fall back to the index file, as "/" is the main file (some cases can override this, but this is the most common method).
-* The server will parse the file according to the handler, for example - let's say that Google are running on PHP.
-   * The server will use the PHP executable to interpret the index file, and catch the output.
-   * The server will return the output, back on the same GET request connection to the customer.
+* The server verifies that the client is allowed to use this method
+(by IP, authentication, etc.).
+* The server goes to pull the content that corresponds with the request,
+in our case it will fall back to the index file, as "/" is the main file
+(some cases can override this, but this is the most common method).
+* The server will parse the file according to the handler, for example -
+let's say that Google are running on PHP.
+   * The server will use the PHP executable to interpret the index file,
+   and catch the output.
+   * The server will return the output, back on the same GET request
+   connection to the customer.
 
 HTML parsing...
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Table of Contents
 The "g" key is pressed
 ----------------------
 The following sections explains all about the physical keyboard and the OS interrupts.
-But, a whole lot happens before that. When you just press "g" the
+But, a whole lot happens after that which isn't explained. When you just press "g" the
 browser receives the event and the entire auto-complete machinery kicks into high gear.
 Depending on your browser's algorithm and if you are in private/incognito mode or not
 various suggestions will be presented to you in the dropbox below the URL bar. Some

--- a/README.rst
+++ b/README.rst
@@ -210,6 +210,8 @@ DNS lookup
 ----------
 
 * Browser checks if the domain is in its cache.
+  (to see DNS Cache list of Chrome browser, go to chrome://net-internals/#dns
+  in Chrome Browser).
 * If not found, the browser calls ``gethostbyname`` library function (varies by
   OS) to do the lookup.
 * ``gethostbyname`` checks if the hostname can be resolved by reference in the

--- a/README.rst
+++ b/README.rst
@@ -531,8 +531,8 @@ The components of the browsers are
   and windows. This backend exposes a generic interface that is not
   platform specific.
   Underneath it uses operating system user interface methods.
-* **JavaScript interpreter.** Used to parse and execute JavaScript code.
-* **Data storage.** This is a persistence layer. The browser may need to
+* **JavaScript interpreter:** Used to parse and execute JavaScript code.
+* **Data storage:** This is a persistence layer. The browser may need to
   save all sorts of data locally, such as cookies. Browsers also support
   storage mechanisms such as localStorage, IndexedDB, WebSQL and
   FileSystem.

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ enter?"
 Except instead of the usual story, we're going to try to answer this question
 in as much detail as possible. No skipping out on anything.
 
-This is a collaborative process, so dig in and try to help out! There's tons of
+This is a collaborative process, so dig in and try to help out! There are tons of
 details missing, just waiting for you to add them! So send us a pull request,
 please!
 
@@ -26,7 +26,7 @@ Table of Contents
 
 The "g" key is pressed
 ----------------------
-The following sections explains the physical keyboard actions
+The following sections explain the physical keyboard actions
 and the OS interrupts. When you press the key "g" the browser receives the
 event and the auto-complete functions kick in.
 Depending on your browser's algorithm and if you are in
@@ -63,7 +63,7 @@ connection, but historically has been over PS/2 or ADB connections.
   declared by the keyboard), so it gets the keycode value stored on it.
 
 - This value goes to the USB SIE (Serial Interface Engine) to be converted in
-  one or more USB packets that follows the low level USB protocol.
+  one or more USB packets that follow the low level USB protocol.
 
 - Those packets are sent by a differential electrical signal over D+ and D-
   pins (the middle 2) at a maximum speed of 1.5 Mb/s, as an HID

--- a/README.rst
+++ b/README.rst
@@ -252,7 +252,7 @@ HTTP Server Request Handle
 --------------------------
 The HTTPD (HTTP Daemon) server is the one handling the requests/responses on
 the server side.
-The HTTPD server can be one of many servers out there, where the most common
+The HTTPD server can be one of several servers out there, where the most common
 ones are Apache for Linux, and IIS for windows.
 
 * The HTTPD (HTTP Daemon) receives the request.
@@ -260,21 +260,21 @@ ones are Apache for Linux, and IIS for windows.
    * HTTP Request Method (GET, POST, HEAD, PUT and DELETE), in our case - GET.
    * Domain, in our case - google.com.
    * Requested path/page, in our case - / (as no specific path/page was
-   requested, / is the default path).
+     requested, / is the default path).
 * The server verifies that there is a Virtual Host configured on the server
-that corresponds with google.com.
+  that corresponds with google.com.
 * The server verifies that google.com can accept GET requests.
 * The server verifies that the client is allowed to use this method
-(by IP, authentication, etc.).
+  (by IP, authentication, etc.).
 * The server goes to pull the content that corresponds with the request,
-in our case it will fall back to the index file, as "/" is the main file
-(some cases can override this, but this is the most common method).
+  in our case it will fall back to the index file, as "/" is the main file
+  (some cases can override this, but this is the most common method).
 * The server will parse the file according to the handler, for example -
-let's say that Google are running on PHP.
+  let's say that Google are running on PHP.
    * The server will use the PHP executable to interpret the index file,
-   and catch the output.
+     and catch the output.
    * The server will return the output, back on the same GET request
-   connection to the customer.
+     connection to the customer.
 
 HTML parsing...
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -270,8 +270,8 @@ The most HTTPD servers are Apache for Linux, and IIS for windows.
   (some cases can override this, but this is the most common method).
 * The server will parse the file according to the handler, for example -
   let's say that Google is running on PHP.
-   * The server will use PHP to interpret the index file, and catch the output.
-   * The server will return the output, on the same request to the client.
+* The server will use PHP to interpret the index file, and catch the output.
+* The server will return the output, on the same request to the client.
 
 HTML parsing...
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ connection, but historically has been over PS/2 or ADB connections.
   in one of its GUI elements (which now is the virtual keyboard application
   buttons).
 
-- The virtual keyboard can now raises a software interrupt for sending a
+- The virtual keyboard can now raise a software interrupt for sending a
   'key pressed' message back to the OS.
 
 - Which in turn notifies the current focused application of a 'key pressed'
@@ -131,7 +131,7 @@ this queue by threads with sufficient privileges calling the
 handled by, an ``NSApplication`` main event loop, via an ``NSEvent`` of
 ``NSEventType`` ``KeyDown``.
 
-(On GNU/Linux) the Xorg server listen for keycodes
+(On GNU/Linux) the Xorg server listens for keycodes
 --------------------------------------------------
 
 When a graphical ``X server`` is used, a re-mapping of keycodes to scancodes
@@ -140,13 +140,13 @@ When the scancode mapping of the key pressed is complete, the ``X server``
 sends the character to the ``window manager`` (DWM, metacity, i3, etc), so the
 ``window manager`` in turn sends the character to the focused window.
 The graphical API of the window  that receives the character prints the
-appropiate font symbol in the appropiate focused field.
+appropriate font symbol in the appropriate focused field.
 
 
 Parse URL
 ---------
 
-* The browser has now the following information contained in the URL (Uniform
+* The browser now has the following information contained in the URL (Uniform
   Resource Locator):
 
     - ``Protocol``  "http"
@@ -219,7 +219,7 @@ If the entry is not in the ARP cache:
 
 * The MAC address of the selected network interface is looked up.
 
-* We send an Layer 2 ARP request:
+* We send a Layer 2 ARP request:
 
 ``ARP Request``::
 
@@ -321,7 +321,7 @@ This send and receive happens multiple times following the TCP connection flow:
      to indicate it is acknowledging receipt of the first packet
 * Client acknowledges the connection by sending a packet:
    * Increases its own sequence number
-   * Increases the receiver acknowledgement number
+   * Increases the receiver acknowledgment number
    * Sets ACK field
 * Data is transferred as follows:
    * As one side sends N data bytes, it increases its SEQ by that number
@@ -346,8 +346,8 @@ TLS handshake
   certificate signed by a CA (Certificate Authority) that also contains a
   public key.
 
-* The client verifies the server digital certificate and cipher a symetric
-  cryptography key using an asymetric cryptography algorithm, attaching the
+* The client verifies the server digital certificate and cipher a symmetric
+  cryptography key using an asymmetric cryptography algorithm, attaching the
   server public key and an encrypted message for verification purposes.
 
 * The server decrypts the key using its private key and decrypts the
@@ -371,7 +371,7 @@ HTTP protocol...
 ----------------
 
 If the web browser used was written by Google, instead of sending an HTTP
-request to retrieve the page, it will send an request to try and negotiate with
+request to retrieve the page, it will send a request to try and negotiate with
 the server an "upgrade" from HTTP to the SPDY protocol.
 
 If the client is using the HTTP protocol and does not support SPDY, it sends a
@@ -493,7 +493,7 @@ Page Rendering
 * Create layers to describe which parts of the page can be animated as a group
   without being re-rasterized. Each frame/render object is assigned to a layer.
 * Textures are allocated for each layer of the page.
-* The frame/render objects for each layers are traversed and drawing commands
+* The frame/render objects for each layer are traversed and drawing commands
   are executed for their respective layer. This may be rasterized by the CPU
   or drawn on the GPU directly using D2D/SkiaGL.
 * All of the above steps may reuse calculated values from the last time the
@@ -508,7 +508,7 @@ Page Rendering
 GPU Rendering
 -------------
 
-* During rendering process the graphical computing layers can use general
+* During the rendering process the graphical computing layers can use general
   purpose ``CPU`` or the graphical processor ``GPU`` as well.
 
 * When using ``GPU`` for graphical rendering computations the graphical

--- a/README.rst
+++ b/README.rst
@@ -252,7 +252,7 @@ HTTP Server Request Handle
 --------------------------
 The HTTPD (HTTP Daemon) server is the one handling the requests/responses on
 the server side.
-The most HTTPD servers are Apache for Linux, and IIS for windows.
+The most common HTTPD servers are Apache for Linux, and IIS for windows.
 
 * The HTTPD (HTTP Daemon) receives the request.
 * The server breaks down the request to the following parameters:

--- a/README.rst
+++ b/README.rst
@@ -367,26 +367,28 @@ TLS handshake
   TLS version, list of cipher algorithms and compression methods available.
 
 * The server replies with a ``Server hello`` message to the client with the
-  TLS version, cipher and compression methods selected + the Server public
-  certificate signed by a CA (Certificate Authority) that also contains a
-  public key.
+  TLS version, selected cipher, selected compression methods and the server's
+  public certificate signed by a CA (Certificate Authority). The certificate
+  contains a public key that will be used by the client to encrypt the rest of
+  the handshake until a symmetric key can be agreed upon.
 
-* The client verifies the server digital certificate and ciphers a symmetric
-  cryptography key using an asymmetric cryptography algorithm, attaching the
-  server public key and an encrypted message for verification purposes.
+* The client verifies the server digital certificate against its list of
+  trusted CAs. If trust is can be established based on the CA, the client
+  generates a string of pseudo-random bytes and encrypts this with the server's
+  public key. These random bytes can be used determine the symmetric key.
 
-* The server decrypts the key using its private key and decrypts the
-  verification message with it, then replies with the verification message
-  decrypted and signed with its private key.
+* The server decrypts the random bytes using its private key and uses these
+  bytes to generate its own copy of the symmetric master key.
 
-* The client confirms the server identity, ciphers the agreed key and sends a
-  ``finished`` message to the server, attaching the encrypted agreed key.
+* The client sends a ``finished`` message to the server, encrypting a hash of
+  the transmissino up to this point with the symmetric key.
 
-* The server sends a ``finished`` message to the client, encrypted with the
-  agreed key.
+* The server decrypts the hash and verifies that the hash matches its own
+  calculation of the hash. If it does, it sends its own ``finished`` message to
+  the client, also encrypted with the symmetric key.
 
 * From now on the TLS session communicates information encrypted with the
-  agreed key.
+  agreed symmetric key.
 
 
 TCP packets

--- a/README.rst
+++ b/README.rst
@@ -516,25 +516,27 @@ common user interface elements are:
 
 The components of the browsers are
 
-* **User interface:** The user interface includes the address bar, back/forward
-  button, bookmarking menu, etc. Every part of the browser display except
-  the window where you see the requested page.
-* **Browser engine:** The browser engine marshals actions between the UI and the rendering
-  engine.
-* **Rendering engine:** The rendering engine is responsible for displaying requested content.
-  For example if the requested content is HTML, the rendering engine parses
-  HTML and CSS, and displays the parsed content on the screen.
-* **Networking:** The networking handles network calls such as HTTP requests, using different
-  implementations for different platform behind a platform-independent
-  interface.
-* **UI backend:** The UI backend is used for drawing basic widgets like combo boxes
-  and windows. This backend exposes a generic interface that is not
+* **User interface:** The user interface includes the address bar, 
+  back/forward button, bookmarking menu, etc. Every part of the browser 
+  display except the window where you see the requested page.
+* **Browser engine:** The browser engine marshals actions between the UI
+  and the rendering engine.
+* **Rendering engine:** The rendering engine is responsible for displaying
+  requested content. For example if the requested content is HTML, the 
+  rendering engine parses HTML and CSS, and displays the parsed content on 
+  the screen.
+* **Networking:** The networking handles network calls such as HTTP requests,
+  using different implementations for different platform behind a 
+  platform-independent interface.
+* **UI backend:** The UI backend is used for drawing basic widgets like combo 
+  boxes and windows. This backend exposes a generic interface that is not
   platform specific.
   Underneath it uses operating system user interface methods.
-* **JavaScript interpreter:** The JavaScript interpreter is used to parse and execute JavaScript code.
-* **Data storage:** The data storage is a persistence layer. The browser may need to
-  save all sorts of data locally, such as cookies. Browsers also support
-  storage mechanisms such as localStorage, IndexedDB, WebSQL and
+* **JavaScript interpreter:** The JavaScript interpreter is used to parse and 
+  execute JavaScript code.
+* **Data storage:** The data storage is a persistence layer. The browser may 
+  need to save all sorts of data locally, such as cookies. Browsers also 
+  support storage mechanisms such as localStorage, IndexedDB, WebSQL and
   FileSystem.
 
 HTML parsing

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ request, please!
 
 This is all licensed under the terms of the `Creative Commons Zero`_ license.
 
-Read this in `简体中文`_ (simplified Chinese) and `한국어`_ (Korean). NOTE: these
+Read this in `简体中文`_ (simplified Chinese), `日本語`_ (Japanese) and `한국어`_ (Korean). NOTE: these
 have not been reviewed by the alex/what-happens-when maintainers.
 
 Table of Contents
@@ -681,5 +681,6 @@ page rendering and painting.
 .. _`varies by OS` : https://en.wikipedia.org/wiki/Hosts_%28file%29#Location_in_the_file_system
 .. _`简体中文`: https://github.com/skyline75489/what-happens-when-zh_CN
 .. _`한국어`: https://github.com/SantonyChoi/what-happens-when-KR
+.. _`日本語`: https://github.com/tettttsuo/what-happens-when-JA
 .. _`downgrade attack`: http://en.wikipedia.org/wiki/SSL_stripping
 .. _`OSI Model`: https://en.wikipedia.org/wiki/OSI_model

--- a/README.rst
+++ b/README.rst
@@ -63,11 +63,11 @@ connection, but historically has been over PS/2 or ADB connections.
 
 *In the case of Virtual Keyboard (as in touch screen devices):*
 
-- In modern capacitive touch screens when the user puts their finger on the
-  screen a tiny amount of current from the electrostatic field of the
-  conductive layer gets transferred to the finger completing the circuit
-  and creating a voltage dropping at that point on the screen so that the
-  ``screen controller`` raises an interrupt reporting the coordinate of
+- In modern capacitive touch screens; when the user puts their finger on the
+  screen, a tiny amount of current from the electrostatic field of the
+  conductive layer gets transferred to the finger. Thus completing the circuit
+  and creating a voltage dropping at that point on the screen. The
+  ``screen controller`` then raises an interrupt reporting the coordinate of
   the 'click'.
 
 - Then the mobile OS notifies the current focused application of a click event

--- a/README.rst
+++ b/README.rst
@@ -407,8 +407,8 @@ The most common HTTPD servers are Apache for Linux, and IIS for windows.
 * The server will use PHP to interpret the index file, and catch the output.
 * The server will return the output, on the same request to the client.
 
-HTML parsing...
----------------
+HTML parsing
+------------
 
 * Fetch contents of requested document from network layer in 8kb chunks.
 * Parse HTML document (See
@@ -419,11 +419,15 @@ HTML parsing...
   files, etc.)
 * Execute synchronous JavaScript code.
 
-CSS interpretation...
----------------------
+CSS interpretation
+------------------
 
 * Parse CSS files and ``<style>`` tag contents using `"CSS lexical and syntax
   grammar"`_
+* Each CSS file is parsed into a ``StyleSheet object``, where each object
+  contains CSS rules with selectors and objects corresponding CSS grammar.
+* A CSS parser can be top-down or bottom-up when a specific parser generator
+  is used.
 
 Page Rendering
 --------------

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,8 @@ to you in the dropbox below the URL bar. Most of these algorithms sort
 and prioritize results based on search history, bookmarks, cookies, and
 popular searches from the internet as a whole. As you are typing
 "google.com" many blocks of code run and the suggestions will be refined
-with each key press. It may even suggest "google.com" before you finish typing it.
+with each key press. It may even suggest "google.com" before you finish typing
+it.
 
 The "enter" key bottoms out
 ---------------------------

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Table of Contents
 The "enter" key bottoms out
 ---------------------------
 
-To pick a zero point, let's choose the enter key on the keyboard hitting the
+To pick a zero point, let's choose the Enter key on the keyboard hitting the
 bottom of its range. At this point, an electrical circuit specific to the enter
 key is closed (either directly or capacitively). This allows a small amount of
 current to flow into the logic circuitry of the keyboard, which scans the state
@@ -77,8 +77,7 @@ connection, but historically has been over PS/2 or ADB connections.
 - The virtual keyboard can now raise a software interrupt for sending a
   'key pressed' message back to the OS.
 
-- Which in turn notifies the current focused application of a 'key pressed'
-  event.
+- This interrupt notifies the current focused application of a 'key pressed' event.
 
 
 Interrupt fires [NOT for USB keyboards]
@@ -177,7 +176,7 @@ Check HSTS list
   HTTPS only.
 * If the website is in the list, the browser sends its request via HTTPS
   instead of HTTP. Otherwise, the initial request is sent via HTTP.
-* (Note that a website can still use the HSTS policy *without* being in the
+  (Note that a website can still use the HSTS policy *without* being in the
   HSTS list.  The first HTTP request to the website by a user will receive a
   response requesting that the user only send HTTPS requests.  However, this
   single HTTP request could potentially leave the user vulnerable to a
@@ -198,48 +197,39 @@ DNS lookup
 ----------
 
 * Browser checks if the domain is in its cache.
-* If not found, calls ``gethostbyname`` library function (varies by OS) to do
-  the lookup.
+* If not found, the browser calls ``gethostbyname`` library function (varies by
+  OS) to do the lookup.
 * ``gethostbyname`` checks if the hostname can be resolved by reference in the
   local ``hosts`` file (whose location `varies by OS`_) before trying to
   resolve the hostname through DNS.
-* If ``gethostbyname`` does not have it cached nor in the ``hosts`` file then a
-  request is made to the known DNS server that was given to the network stack.
+* If ``gethostbyname`` does not have it cached nor can find it in the ``hosts``
+  file then it makes a request to the DNS server configured in the network stack.
   This is typically the local router or the ISP's caching DNS server.
-
-* The local DNS server is looked up.
-
-* If the DNS server is on the same subnet the ARP cache is checked for an ARP
-  entry for the DNS server. If there is no entry in the ARP cache we do the
-  ``ARP process`` (see below) for the DNS server. If there is an entry in the
-  ARP cache, we get the information: DNS.server.ip.address = dns:mac:address
-
-* If the DNS server is on a different subnet, we check the ARP cache for the
-  default gateway IP. If we do not have an entry in the ARP cache we do the
-  ``ARP process`` (see below) for the default gateway IP. If we have an entry
-  in the ARP cache, we get the information:
-  default.gateway.ip.address = gateway:mac:address
+* If the DNS server is on the same subnet the network library follows the
+  ``ARP process`` below for the DNS server.
+* If the DNS server is on a different subnet, the network library follows
+  the ``ARP process`` below for the default gateway IP.
 
 
 ARP process
 -----------
-In order to send an ARP broadcast we need to have a Target IP address we want
-to look up. We also need to know the MAC address of the interface we are going
-to use to send out the ARP broadcast.
+In order to send an ARP broadcast the network stack lbirary needs the target IP
+address to look up. It also needs to know the MAC address of the interface it will
+use to send out the ARP broadcast.
 
-* The ARP cache is checked for an ARP entry for our target IP. If it's in the
-  cache, we return the result: Target IP = MAC.
+The ARP cache is first checked for an ARP entry for our target IP. If it is in the
+cache, the library function returns the result: Target IP = MAC.
 
 If the entry is not in the ARP cache:
 
 * The route table is looked up, to see if the Target IP address is on any of
-  the subnets on the local route table. If it is, we use the interface
-  associated with that subnet. If it is not, we use the interface that has the
-  subnet of our default gateway.
+  the subnets on the local route table. If it is, the library uses the interface
+  associated with that subnet. If it is not, the library uses the interface that has
+  the subnet of our default gateway.
 
 * The MAC address of the selected network interface is looked up.
 
-* We send a Layer 2 ARP request:
+* The network library send a Layer 2 ARP request:
 
 ``ARP Request``::
 
@@ -248,23 +238,23 @@ If the entry is not in the ARP cache:
     Target MAC: FF:FF:FF:FF:FF:FF (Broadcast)
     Target IP: target.ip.goes.here
 
-Depending on what type of hardware we have between us and the router:
+Depending on what type of hardware is between the computer and the router:
 
 Directly connected:
 
-* If we are directly connected to the router the router will respond with an
+* If the computer is directly connected to the router the router responds with an
   ``ARP Reply`` (see below)
 
 Hub:
 
-* If we are connected to a HUB the HUB will broadcast the ARP request out all
-  other ports of the HUB. If the router is connected on the same "wire" it will
-  respond with an ``ARP Reply`` (see below).
+* If the computer is connected to a hub the hub will broadcast the ARP request out all
+  other ports. If the router is connected on the same "wire" it will respond with an
+  ``ARP Reply`` (see below).
 
 Switch:
 
-* If we are connected to a switch it will check it's local CAM/MAC table to see
-  which port has the MAC address we are looking for. If the switch has no entry
+* If the computer is connected to a switch the switch will check it's local CAM/MAC table
+  to see which port has the MAC address we are looking for. If the switch has no entry
   for the MAC address it will rebroadcast the ARP request to all other ports.
 
 * If the switch has an entry in the MAC/CAM table it will send the ARP request
@@ -280,8 +270,8 @@ Switch:
     Target MAC: interface:mac:address:here
     Target IP: interface.ip.goes.here
 
-Now that we have the IP address of either our DNS server or the default gateway
-we can resume our DNS process:
+Now that the network library has the IP address of either our DNS server or
+the default gateway it can resume its DNS process:
 
 * Port 53 is opened to send a UDP request to DNS server (if the response size
   is too large, TCP will be used instead).
@@ -434,7 +424,7 @@ for further requests.
 If the HTTP headers sent by the web browser included sufficient information for
 the web server to determine if the version of the file cached by the web
 browser has been unmodified since the last retrieval (ie. if the web browser
-included an ``ETag`` header), it may have instead respond with a request of
+included an ``ETag`` header), it may instead respond with a request of
 the form::
 
     304 Not Modified
@@ -442,28 +432,29 @@ the form::
 
 and no payload, and the web browser instead retrieves the HTML from its cache.
 
-After parsing the HTML, the web browser (and server) will repeat this process
+After parsing the HTML, the web browser (and server) repeats this process
 for every resource (image, CSS, favicon.ico, etc) referenced by the HTML page,
 except instead of ``GET / HTTP/1.1`` the request will be
 ``GET /$(URL relative to www.google.com) HTTP/1.1``.
 
 If the HTML referenced a resource on a different domain than
-``www.google.com``, the web browser will go back to the steps involved in
-resolving the other domain, and follow all steps up to this point for that
+``www.google.com``, the web browser goes back to the steps involved in
+resolving the other domain, and follows all steps up to this point for that
 domain. The ``Host`` header in the request will be set to the appropriate
 server name instead of ``google.com``.
 
 HTTP Server Request Handle
 --------------------------
 The HTTPD (HTTP Daemon) server is the one handling the requests/responses on
-the server side.
-The most common HTTPD servers are Apache for Linux, and IIS for windows.
+the server side. The most common HTTPD servers are Apache or nginx for Linux
+and IIS for Windows.
 
 * The HTTPD (HTTP Daemon) receives the request.
 * The server breaks down the request to the following parameters:
-   * HTTP Request Method (GET, POST, HEAD, PUT and DELETE), in our case - GET.
-   * Domain, in our case - google.com.
-   * Requested path/page, in our case - / (as no specific path/page was
+   * HTTP Request Method (either GET, POST, HEAD, PUT and DELETE). In the case
+     of a URL entered directly into the address bar, this will be GET.
+   * Domain, in this case - google.com.
+   * Requested path/page, in this case - / (as no specific path/page was
      requested, / is the default path).
 * The server verifies that there is a Virtual Host configured on the server
   that corresponds with google.com.
@@ -477,15 +468,14 @@ The most common HTTPD servers are Apache for Linux, and IIS for windows.
 * The server goes to pull the content that corresponds with the request,
   in our case it will fall back to the index file, as "/" is the main file
   (some cases can override this, but this is the most common method).
-* The server will parse the file according to the handler. For example, let's
-  say that Google is running on PHP. The server will use PHP to interpret the
-  index file, and catch the output.
-* The server will return the output, on the same request to the client.
+* The server parses the file according to the handler. If Google
+  is running on PHP, the server uses PHP to interpret the index file, and
+  streams the output to the client.
 
 Behind the scenes of the Browser
 ----------------------------------
 
-Once the server supplies the resources (HTML, CSS, JS, Image, etc.,)
+Once the server supplies the resources (HTML, CSS, JS, images, etc.)
 to the browser it undergoes the below process:
 
 * Parsing - HTML, CSS, JS
@@ -546,7 +536,7 @@ The components of the browsers are:
 HTML parsing
 ------------
 
-The rendering engine will start getting the contents of the requested
+The rendering engine starts getting the contents of the requested
 document from the networking layer. This will usually be done in 8kB chunks.
 
 The primary job of HTML parser to parse the HTML markup into a parse tree.
@@ -554,8 +544,9 @@ The primary job of HTML parser to parse the HTML markup into a parse tree.
 The output tree (the "parse tree") is a tree of DOM element and attribute
 nodes. DOM is short for Document Object Model. It is the object presentation
 of the HTML document and the interface of HTML elements to the outside world
-like JavaScript. The root of the tree is the "Document" object. The DOM has
-an almost one-to-one relation to the markup.
+like JavaScript. The root of the tree is the "Document" object. Prior of
+any manipulation via scripting, the DOM has an almost one-to-one relation to
+the markup.
 
 **The parsing algorithm**
 
@@ -571,7 +562,7 @@ The reasons are:
   containing `document.write()` calls) can add extra tokens, so the parsing
   process actually modifies the input.
 
-Unable to use the regular parsing techniques, browsers create custom
+Unable to use the regular parsing techniques, the browser utilizes a custom
 parsers for parsing HTML. The parsing algorithm is described in
 detail by the HTML5 specification.
 
@@ -579,23 +570,16 @@ The algorithm consists of two stages: tokenization and tree construction.
 
 **Actions when the parsing is finished**
 
-At this stage the browser will mark the document as interactive and start
+The browser begins fetching external resources linked to the page (CSS, images,
+JavaScript files, etc.).
+
+At this stage the browser marks the document as interactive and starts
 parsing scripts that are in "deferred" mode: those that should be
-executed after the document is parsed. The document state will be then
-set to "complete" and a "load" event will be fired.
+executed after the document is parsed. The document state is
+set to "complete" and a "load" event is fired.
 
-You can see the full algorithms for tokenization and tree construction
-in the HTML5 specification
-
-**Browser's error tolerance**
-
-You never get an "Invalid Syntax" error on an HTML page. Browsers fix
+Note there is never an "Invalid Syntax" error on an HTML page. Browsers fix
 any invalid content and go on.
-
-Fetch/prefetch external resources linked to the page (CSS, Images, JavaScript
-files, etc.)
-
-Execute synchronous JavaScript code.
 
 CSS interpretation
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -467,8 +467,9 @@ and IIS for Windows.
 
 * The HTTPD (HTTP Daemon) receives the request.
 * The server breaks down the request to the following parameters:
-   * HTTP Request Method (either GET, POST, HEAD, PUT and DELETE). In the case
-     of a URL entered directly into the address bar, this will be GET.
+   * HTTP Request Method (either GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS
+     and TRACE). In the case of a URL entered directly into the address bar,
+     this will be GET.
    * Domain, in this case - google.com.
    * Requested path/page, in this case - / (as no specific path/page was
      requested, / is the default path).

--- a/README.rst
+++ b/README.rst
@@ -303,10 +303,10 @@ your computer, possibly through a local network, and then through a modem
 signal suitable for transmission over telephone, cable, or wireless telephony
 connections. On the other end of the connection is another modem which converts
 the analog signal back into digital data to be processed by the next `network
-node`_ where its from and to addresses would be analyzed further.
+node`_ where the from and to addresses would be analyzed further.
 
-Most larger businesses and some newer residential connections will have fibre
-or direct Ethernet connections, in which case the data remains digital, and
+Most larger businesses and some newer residential connections will have fiber
+or direct Ethernet connections in which case the data remains digital and
 is passed directly to the next `network node`_ for processing.
 
 Eventually, the packet will reach the router managing the local subnet. From

--- a/README.rst
+++ b/README.rst
@@ -516,23 +516,23 @@ common user interface elements are:
 
 The components of the browsers are
 
-* **The user interface:** this includes the address bar, back/forward
+* **User interface:** The user interface includes the address bar, back/forward
   button, bookmarking menu, etc. Every part of the browser display except
   the window where you see the requested page.
-* **The browser engine:** marshals actions between the UI and the rendering
+* **Browser engine:** The browser engine marshals actions between the UI and the rendering
   engine.
-* **The rendering engine:** responsible for displaying requested content.
+* **Rendering engine:** The rendering engine is responsible for displaying requested content.
   For example if the requested content is HTML, the rendering engine parses
   HTML and CSS, and displays the parsed content on the screen.
-* **Networking:** for network calls such as HTTP requests, using different
+* **Networking:** The networking handles network calls such as HTTP requests, using different
   implementations for different platform behind a platform-independent
   interface.
-* **UI backend:** used for drawing basic widgets like combo boxes
+* **UI backend:** The UI backend is used for drawing basic widgets like combo boxes
   and windows. This backend exposes a generic interface that is not
   platform specific.
   Underneath it uses operating system user interface methods.
-* **JavaScript interpreter:** Used to parse and execute JavaScript code.
-* **Data storage:** This is a persistence layer. The browser may need to
+* **JavaScript interpreter:** The JavaScript interpreter is used to parse and execute JavaScript code.
+* **Data storage:** The data storage is a persistence layer. The browser may need to
   save all sorts of data locally, such as cookies. Browsers also support
   storage mechanisms such as localStorage, IndexedDB, WebSQL and
   FileSystem.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 What happens when...
 ====================
 
-This repository is an attempt to answer the age old interview question "What
+This repository is an attempt to answer the age-old interview question "What
 happens when you type google.com into your browser's address box and press
 enter?"
 
@@ -36,7 +36,7 @@ to you in the dropdown below the URL bar. Most of these algorithms sort
 and prioritize results based on search history, bookmarks, cookies, and
 popular searches from the internet as a whole. As you are typing
 "google.com" many blocks of code run and the suggestions will be refined
-with each key press. It may even suggest "google.com" before you finish typing
+with each keypress. It may even suggest "google.com" before you finish typing
 it.
 
 The "enter" key bottoms out
@@ -64,11 +64,11 @@ connection, but historically has been over PS/2 or ADB connections.
   declared by the keyboard), so it gets the keycode value stored on it.
 
 - This value goes to the USB SIE (Serial Interface Engine) to be converted in
-  one or more USB packets that follow the low level USB protocol.
+  one or more USB packets that follow the low-level USB protocol.
 
 - Those packets are sent by a differential electrical signal over D+ and D-
   pins (the middle 2) at a maximum speed of 1.5 Mb/s, as an HID
-  (Human Interface Device) device is always declared to be a "low speed device"
+  (Human Interface Device) device is always declared to be a "low-speed device"
   (USB 2.0 compliance).
 
 - This serial signal is then decoded at the computer's host USB controller, and
@@ -83,16 +83,16 @@ connection, but historically has been over PS/2 or ADB connections.
   circuit through the electrostatic field of the conductive layer and
   creates a voltage drop at that point on the screen. The
   ``screen controller`` then raises an interrupt reporting the coordinate of
-  the key press.
+  the keypress.
 
-- Then the mobile OS notifies the current focused application of a press event
+- Then the mobile OS notifies the currently focused application of a press event
   in one of its GUI elements (which now is the virtual keyboard application
   buttons).
 
 - The virtual keyboard can now raise a software interrupt for sending a
   'key pressed' message back to the OS.
 
-- This interrupt notifies the current focused application of a 'key pressed'
+- This interrupt notifies the currently focused application of a 'key pressed'
   event.
 
 
@@ -110,7 +110,7 @@ the appropriate handler. Thus, the kernel is entered.
 --------------------------------------------------------
 
 The HID transport passes the key down event to the ``KBDHID.sys`` driver which
-converts the HID usage into a scancode. In this case the scan code is
+converts the HID usage into a scancode. In this case, the scan code is
 ``VK_RETURN`` (``0x0D``). The ``KBDHID.sys`` driver interfaces with the
 ``KBDCLASS.sys`` (keyboard class driver). This driver is responsible for
 handling all keyboard and keypad input in a secure manner. It then calls into
@@ -183,7 +183,7 @@ the text given in the address box to the browser's default web search engine.
 In many cases the URL has a special piece of text appended to it to tell the
 search engine that it came from a particular browser's URL bar.
 
-Convert non-ASCII Unicode characters in hostname
+Convert non-ASCII Unicode characters in the hostname
 ------------------------------------------------
 
 * The browser checks the hostname for characters that are not in ``a-z``,
@@ -229,7 +229,7 @@ ARP process
 -----------
 
 In order to send an ARP (Address Resolution Protocol) broadcast the network
-stack library needs the target IP address to look up. It also needs to know the
+stack library needs the target IP address to lookup. It also needs to know the
 MAC address of the interface it will use to send out the ARP broadcast.
 
 The ARP cache is first checked for an ARP entry for our target IP. If it is in
@@ -258,13 +258,13 @@ Depending on what type of hardware is between the computer and the router:
 
 Directly connected:
 
-* If the computer is directly connected to the router the router responds
+* If the computer is directly connected to the router the router response
   with an ``ARP Reply`` (see below)
 
 Hub:
 
 * If the computer is connected to a hub, the hub will broadcast the ARP
-  request out all other ports. If the router is connected on the same "wire",
+  request out of all other ports. If the router is connected on the same "wire",
   it will respond with an ``ARP Reply`` (see below).
 
 Switch:
@@ -410,7 +410,7 @@ control`_. This varies depending on the sender; the most common algorithms are
   (MSS) of the connection.
 * For each packet acknowledged, the window doubles in size until it reaches the
   'slow-start threshold'. In some implementations, this threshold is adaptive.
-* After reaching the slow start threshold, the window increases additively for
+* After reaching the slow-start threshold, the window increases additively for
   each packet acknowledged. If a packet is dropped, the window reduces
   exponentially until another packet is acknowledged.
 
@@ -430,7 +430,7 @@ request to the server of the form::
     [other headers]
 
 where ``[other headers]`` refers to a series of colon-separated key-value pairs
-formatted as per the HTTP specification and separated by single new lines.
+formatted as per the HTTP specification and separated by single newlines.
 (This assumes the web browser being used doesn't have any bugs violating the
 HTTP spec. This also assumes that the web browser is using ``HTTP/1.1``,
 otherwise it may not include the ``Host`` header in the request and the version
@@ -459,7 +459,7 @@ headers sent by the client requested it, keep the connection open to be reused
 for further requests.
 
 If the HTTP headers sent by the web browser included sufficient information for
-the web server to determine if the version of the file cached by the web
+the webserver to determine if the version of the file cached by the web
 browser has been unmodified since the last retrieval (ie. if the web browser
 included an ``ETag`` header), it may instead respond with a request of
 the form::
@@ -467,7 +467,7 @@ the form::
     304 Not Modified
     [response headers]
 
-and no payload, and the web browser instead retrieves the HTML from its cache.
+and no payload, and the web browser instead retrieve the HTML from its cache.
 
 After parsing the HTML, the web browser (and server) repeats this process
 for every resource (image, CSS, favicon.ico, etc) referenced by the HTML page,
@@ -483,7 +483,7 @@ server name instead of ``google.com``.
 HTTP Server Request Handle
 --------------------------
 The HTTPD (HTTP Daemon) server is the one handling the requests/responses on
-the server side. The most common HTTPD servers are Apache or nginx for Linux
+the server-side. The most common HTTPD servers are Apache or nginx for Linux
 and IIS for Windows.
 
 * The HTTPD (HTTP Daemon) receives the request.
@@ -544,7 +544,7 @@ common user interface elements are:
   current documents
 * Home button that takes you to your home page
 
-**Browser High Level Structure**
+**Browser High-Level Structure**
 
 The components of the browsers are:
 
@@ -562,7 +562,7 @@ The components of the browsers are:
   platform-independent interface.
 * **UI backend:** The UI backend is used for drawing basic widgets like combo
   boxes and windows. This backend exposes a generic interface that is not
-  platform specific.
+  platform-specific.
   Underneath it uses operating system user interface methods.
 * **JavaScript engine:** The JavaScript engine is used to parse and
   execute JavaScript code.
@@ -577,12 +577,12 @@ HTML parsing
 The rendering engine starts getting the contents of the requested
 document from the networking layer. This will usually be done in 8kB chunks.
 
-The primary job of HTML parser is to parse the HTML markup into a parse tree.
+The primary job of the HTML parser is to parse the HTML markup into a parse tree.
 
 The output tree (the "parse tree") is a tree of DOM element and attribute
 nodes. DOM is short for Document Object Model. It is the object presentation
 of the HTML document and the interface of HTML elements to the outside world
-like JavaScript. The root of the tree is the "Document" object. Prior of
+like JavaScript. The root of the tree is the "Document" object. Prior to
 any manipulation via scripting, the DOM has an almost one-to-one relation to
 the markup.
 
@@ -634,7 +634,7 @@ Page Rendering
 
 * Create a 'Frame Tree' or 'Render Tree' by traversing the DOM nodes, and
   calculating the CSS style values for each node.
-* Calculate the preferred width of each node in the 'Frame Tree' bottom up
+* Calculate the preferred width of each node in the 'Frame Tree' bottom-up
   by summing the preferred width of the child nodes and the node's
   horizontal margins, borders, and padding.
 * Calculate the actual width of each node top-down by allocating each node's
@@ -681,7 +681,7 @@ Window Server
 Post-rendering and user-induced execution
 -----------------------------------------
 
-After rendering has completed, the browser executes JavaScript code as a result
+After rendering has been completed, the browser executes JavaScript code as a result
 of some timing mechanism (such as a Google Doodle animation) or user
 interaction (typing a query into the search box and receiving suggestions).
 Plugins such as Flash or Java may execute as well, although not at this time on

--- a/README.rst
+++ b/README.rst
@@ -358,9 +358,6 @@ This send and receive happens multiple times following the TCP connection flow:
    * The other sides ACKs the FIN packet and sends its own FIN
    * The closer acknowledges the other side's FIN with an ACK
 
-UDP packets
-~~~~~~~~~~~
-
 TLS handshake
 -------------
 * The client computer sends a ``ClientHello`` message to the server with its
@@ -373,26 +370,22 @@ TLS handshake
   the handshake until a symmetric key can be agreed upon.
 
 * The client verifies the server digital certificate against its list of
-  trusted CAs. If trust is can be established based on the CA, the client
+  trusted CAs. If trust can be established based on the CA, the client
   generates a string of pseudo-random bytes and encrypts this with the server's
   public key. These random bytes can be used determine the symmetric key.
 
 * The server decrypts the random bytes using its private key and uses these
   bytes to generate its own copy of the symmetric master key.
 
-* The client sends a ``finished`` message to the server, encrypting a hash of
-  the transmissino up to this point with the symmetric key.
+* The client sends a ``Finished`` message to the server, encrypting a hash of
+  the transmission up to this point with the symmetric key.
 
-* The server decrypts the hash and verifies that the hash matches its own
-  calculation of the hash. If it does, it sends its own ``finished`` message to
+* The server generates its own hash, and then decrypts the client-sent hash
+  to verify that it matches. If it does, it sends its own ``Finished`` message to
   the client, also encrypted with the symmetric key.
 
-* From now on the TLS session communicates information encrypted with the
-  agreed symmetric key.
-
-
-TCP packets
-~~~~~~~~~~~
+* From now on the TLS session transmits the application (HTTP) data encrypted with
+  the agreed symmetric key.
 
 HTTP protocol
 -------------

--- a/README.rst
+++ b/README.rst
@@ -484,7 +484,7 @@ to browser it undergoes the below process
 
 * Parsing - HTML, CSS, JS
 * Rendering - Construct DOM Tree → Render Tree → Layout of Render Tree →
-Painting the render tree
+  Painting the render tree
 
 Browser
 -------
@@ -507,29 +507,29 @@ common user interface elements are:
 * Back and forward buttons
 * Bookmarking options
 * Refresh and stop buttons for refreshing or stopping the loading of
-current documents
+  current documents
 * Home button that takes you to your home page
 
 ** Browser High Level Structure **
 
 The components of the browsers are
 * **The user interface:** this includes the address bar, back/forward button,
-bookmarking menu, etc. Every part of the browser display except the window
-where you see the requested page.
+  bookmarking menu, etc. Every part of the browser display except the window
+  where you see the requested page.
 * **The browser engine:** marshals actions between the UI and the rendering
-engine.
+  engine.
 * **The rendering engine:** responsible for displaying requested content.
-For example if the requested content is HTML, the rendering engine parses
-HTML and CSS, and displays the parsed content on the screen.
+  For example if the requested content is HTML, the rendering engine parses
+  HTML and CSS, and displays the parsed content on the screen.
 * **Networking:** for network calls such as HTTP requests, using different
-implementations for different platform behind a platform-independent interface.
+  implementations for different platform behind a platform-independent interface.
 * **UI backend:** used for drawing basic widgets like combo boxes and windows.
-This backend exposes a generic interface that is not platform specific.
-Underneath it uses operating system user interface methods.
+  This backend exposes a generic interface that is not platform specific.
+  Underneath it uses operating system user interface methods.
 * **JavaScript interpreter.** Used to parse and execute JavaScript code.
 * **Data storage.** This is a persistence layer. The browser may need to save
-all sorts of data locally, such as cookies. Browsers also support storage
-mechanisms such as localStorage, IndexedDB, WebSQL and FileSystem.
+  all sorts of data locally, such as cookies. Browsers also support storage
+  mechanisms such as localStorage, IndexedDB, WebSQL and FileSystem.
 
 HTML parsing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -290,8 +290,9 @@ Switch:
 Now that the network library has the IP address of either our DNS server or
 the default gateway it can resume its DNS process:
 
-* Port 53 is opened to send a UDP request to DNS server (if the response size
-  is too large, TCP will be used instead).
+* The DNS client establishes a socket to UDP port 53 on the DNS server,
+  using a source port above 1023.
+* If the response size is too large, TCP will be used instead.
 * If the local/ISP DNS server does not have it, then a recursive search is
   requested and that flows up the list of DNS servers until the SOA is reached,
   and if found an answer is returned.

--- a/README.rst
+++ b/README.rst
@@ -505,7 +505,7 @@ standards organization for the web.
 Browser user interfaces have a lot in common with each other. Among the
 common user interface elements are:
 
-* Address bar for inserting a URI
+* An address bar for inserting a URI
 * Back and forward buttons
 * Bookmarking options
 * Refresh and stop buttons for refreshing or stopping the loading of
@@ -526,7 +526,7 @@ The components of the browsers are
   rendering engine parses HTML and CSS, and displays the parsed content on
   the screen.
 * **Networking:** The networking handles network calls such as HTTP requests,
-  using different implementations for different platform behind a
+  using different implementations for different platforms behind a
   platform-independent interface.
 * **UI backend:** The UI backend is used for drawing basic widgets like combo
   boxes and windows. This backend exposes a generic interface that is not
@@ -582,7 +582,7 @@ set to "complete" and a "load" event will be fired.
 You can see the full algorithms for tokenization and tree construction
 in the HTML5 specification
 
-**Browsers error tolerance**
+**Browser's error tolerance**
 
 You never get an "Invalid Syntax" error on an HTML page. Browsers fix
 any invalid content and go on.

--- a/README.rst
+++ b/README.rst
@@ -63,10 +63,7 @@ connection, but historically has been over PS/2 or ADB connections.
 
 *In the case of Virtual Keyboard (as in touch screen devices):*
 
-- In modern capacitive touch screens; when the user puts their finger on the
-  screen, a tiny amount of current from the electrostatic field of the
-  conductive layer gets transferred to the finger. Thus completing the circuit
-  and creating a voltage dropping at that point on the screen. The
+- When the user puts their finger on a modern capacitive touch screen, a tiny amount of current gets transferred to the finger. This completes the circuit through the electrostatic field of the conductive layer and creates a voltage drop at that point on the screen. The
   ``screen controller`` then raises an interrupt reporting the coordinate of
   the 'click'.
 

--- a/README.rst
+++ b/README.rst
@@ -302,8 +302,8 @@ your computer, possibly through a local network, and then through a modem
 (MOdulator/DEModulator) which converts digital 1's and 0's into an analog
 signal suitable for transmission over telephone, cable, or wireless telephony
 connections. On the other end of the connection is another modem which converts
-the analog singnal back into digital signals to be processed by the next
-`network node`_ where its from and to addresses would be analyzed further.
+the analog signal back into digital data to be processed by the next `network
+node`_ where its from and to addresses would be analyzed further.
 
 Most larger businesses and some newer residential connections will have fibre
 or direct Ethernet connections, in which case the data remains digital, and

--- a/README.rst
+++ b/README.rst
@@ -471,8 +471,8 @@ and IIS for Windows.
 * The HTTPD (HTTP Daemon) receives the request.
 * The server breaks down the request to the following parameters:
    * HTTP Request Method (either ``GET``, ``HEAD``, ``POST``, ``PUT``,
-     ``DELETE``, ``CONNECT``, ``OPTIONS``, or ``TRACE``). In the case of a URL
-     entered directly into the address bar, this will be ``GET``.
+     ``PATCH``, ``DELETE``, ``CONNECT``, ``OPTIONS``, or ``TRACE``). In the
+     case of a URL entered directly into the address bar, this will be ``GET``.
    * Domain, in this case - google.com.
    * Requested path/page, in this case - / (as no specific path/page was
      requested, / is the default path).

--- a/README.rst
+++ b/README.rst
@@ -466,6 +466,15 @@ Page Rendering
 GPU Rendering
 -------------
 
+* During rendering process the graphical computing layers can use general
+  purpose ``CPU`` or the grhapical processor ``GPU`` as well.
+
+* When using ``GPU`` for graphical rendering computations the graphical
+  software layers split the task into multple pieces, so it can take advantage
+  of ``GPU`` massive parallelism for float point calculations requiered for
+  the rendering process.
+
+
 Window Server
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -297,12 +297,17 @@ At this point the packet is ready to be transmitted through either:
 * `WiFi`_
 * `Cellular data network`_
 
-In all cases the last point at which the packet leaves your computer is a
-digital-to-analog (DAC) converter which fires off electrical 1's and 0's on a
-wire. On the other end of the physical bit transfer is an `analog-to-digital
-converter`_  which converts the electrical bits into logic signals to be
-processed by the next `network node`_ where its from and to addresses would be
-analyzed further.
+For most home or small business Internet connections the packet will pass from
+your computer, possibly through a local network, and then through a modem
+(MOdulator/DEModulator) which converts digital 1's and 0's into an analog
+signal suitable for transmission over telephone, cable, or wireless telephony
+connections. On the other end of the connection is another modem which converts
+the analog singnal back into digital signals to be processed by the next
+`network node`_ where its from and to addresses would be analyzed further.
+
+Most larger businesses and some newer residential connections will have fibre
+or direct Ethernet connections, in which case the data remains digital, and
+is passed directly to the next `network node`_ for processing.
 
 Eventually, the packet will reach the router managing the local subnet. From
 there, it will continue to travel to the AS's border routers, other ASes, and

--- a/README.rst
+++ b/README.rst
@@ -26,19 +26,24 @@ The keyboard controller then encodes the keycode for transport to the computer.
 This is now almost universally over a Universal Serial Bus (USB) or Bluetooth
 connection, but historically has been over PS/2 or ADB connections.
 
-In the case of the USB example: the USB circuitry of the keyboard is powered
+In the case of the USB keyboard: the USB circuitry of the keyboard is powered
 by the 5V supply provided over pin 1 from the computer's USB host controller.
-17.78 mA of this current is returned on either the D+ or D- pin (the middle 2)
-of the keyboard's USB connector. Which pin carries the current is
-toggled between the two creating a high speed bitstream (the rate depending on
-USB 1, 2, or 3) serially encoding the digital value of the enter key.  This
-serial signal is then decoded at the computer's host USB controller, and
+The keycode generated is stored by internal keyboard circuitry memory in a register
+called "endpoint".
+The host USB contoller polls that "endpoint" every ~10ms (minimum value declared by
+the keyboard), so it gets the keycode value stored on it.
+This value goes to the USB SIE (Serial Interface Engine) to be converted in one or 
+more USB packets that follows the low level USB protocol.
+Those packets are sent by a diferential electrical signal over D+ and D- pins
+(the middle 2) at a maximum speed of 1.5 Mb/s, as an HID  (Human Interface Devide)
+device is always declared to be a "low speed device" (USB 2.0 compliance).  
+This serial signal is then decoded at the computer's host USB controller, and
 interpreted by the computer's Human Interface Device (HID) universal keyboard
 device driver.  The value of the key is then passed into the operating system's
 hardware abstraction layer.
 
-Interrupt fires...
-------------------
+Interrupt fires [NOT for USB keyboards]
+---------------------------------------
 
 The keyboard sends signals on its interrupt request line (IRQ), which is mapped
 to an ``interrupt vector`` (integer) by the interrupt controller. The CPU uses

--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,8 @@ Is it a URL or a search term?
 
 When no protocol or valid domain name is given the browser proceeds to feed
 the text given in the address box to the browser's default web search engine.
+In many cases the url has a special peice of text appended to it to tell the
+search engine that it came from a particular browser's url bar.
 
 
 Check HSTS list...

--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,18 @@ the text given in the address box to the browser's default web search engine.
 
 Check HSTS list...
 ------------------
+* The browser checks its "preloaded HSTS (HTTP Strict Transport Security)"
+  list. This is a list of websites that have requested to be contacted via
+  HTTPS only.
+* If the website is in the list, the browser sends its request via HTTP instead
+  of HTTPS.  Else, the initial request is sent via HTTP.
+* (Note that a website can still use the HSTS policy *without* being in the
+  HSTS list.  The first HTTP request to the website by a user will receive a
+  response requesting that the user only send HTTPS requests.  However, this
+  single HTTP request could potentially leave the user vulnerable to a
+  `downgrade attack`_, which is why the HSTS list is included in modern web
+  browsers.)
+
 
 Convert non-ASCII Unicode characters in hostname
 ------------------------------------------------
@@ -556,3 +568,4 @@ page rendering and painting.
 .. _`network node`: https://en.wikipedia.org/wiki/Computer_network#Network_nodes
 .. _`varies by OS` : https://en.wikipedia.org/wiki/Hosts_%28file%29#Location_in_the_file_system
 .. _`简体中文`: https://github.com/skyline75489/what-happens-when-zh_CN
+.. _`downgrade attack`: http://en.wikipedia.org/wiki/SSL_stripping

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ What happens when...
 ====================
 
 This repository is an attempt to answer the age old interview question "What
-happens when you type google.com into your browser and press enter?"
+happens when you type google.com into your browser's address box and press enter?"
 
 Except instead of the usual story, we're going to try to answer this question
 in as much detail as possible. No skipping out on anything.
@@ -160,7 +160,7 @@ Is it a URL or a search term?
 -----------------------------
 
 When no protocol or valid domain name is given the browser proceeds to feed
-the text given in the URL bar to its default web search engine.
+the text given in the address box to the browser's default web search engine.
 
 
 Check HSTS list...

--- a/README.rst
+++ b/README.rst
@@ -578,7 +578,7 @@ The reasons are:
   process actually modifies the input.
 
 Unable to use the regular parsing techniques, the browser utilizes a custom
-parsers for parsing HTML. The parsing algorithm is described in
+parser for parsing HTML. The parsing algorithm is described in
 detail by the HTML5 specification.
 
 The algorithm consists of two stages: tokenization and tree construction.

--- a/README.rst
+++ b/README.rst
@@ -245,7 +245,7 @@ If the entry is not in the ARP cache:
 
     Sender MAC: interface:mac:address:here
     Sender IP: interface.ip.goes.here
-    Target MAC: 255.255.255.255 (Broadcast)
+    Target MAC: FF:FF:FF:FF:FF:FF (Broadcast)
     Target IP: target.ip.goes.here
 
 Depending on what type of hardware we have between us and the router:

--- a/README.rst
+++ b/README.rst
@@ -604,7 +604,7 @@ Execute synchronous JavaScript code.
 CSS interpretation
 ------------------
 
-* Parse CSS files, ``<style>`` tag contents, and ''style'' attribute 
+* Parse CSS files, ``<style>`` tag contents, and ''style'' attribute
   values using `"CSS lexical and syntax grammar"`_
 * Each CSS file is parsed into a ``StyleSheet object``, where each object
   contains CSS rules with selectors and objects corresponding CSS grammar.

--- a/README.rst
+++ b/README.rst
@@ -301,7 +301,7 @@ Opening of a socket
 Once the browser receives the IP address of the destination server, it takes
 that and the given port number from the URL (the HTTP protocol defaults to port
 80, and HTTPS to port 443), and makes a call to the system library function
-named ``socket`` and requests a TCP socket stream - ``AF_INET`` and
+named ``socket`` and requests a TCP socket stream - ``AF_INET/AF_INET6`` and
 ``SOCK_STREAM``.
 
 * This request is first passed to the Transport Layer where a TCP segment is

--- a/README.rst
+++ b/README.rst
@@ -179,8 +179,8 @@ Is it a URL or a search term?
 
 When no protocol or valid domain name is given the browser proceeds to feed
 the text given in the address box to the browser's default web search engine.
-In many cases the url has a special piece of text appended to it to tell the
-search engine that it came from a particular browser's url bar.
+In many cases the URL has a special piece of text appended to it to tell the
+search engine that it came from a particular browser's URL bar.
 
 Convert non-ASCII Unicode characters in hostname
 ------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -564,7 +564,7 @@ an almost one-to-one relation to the markup.
 
 **The parsing algorithm**
 
-HTML cannot be parsed using the regular top down or bottom up parsers.
+HTML cannot be parsed using the regular top-down or bottom-up parsers.
 
 The reasons are:
 * The forgiving nature of the language.

--- a/README.rst
+++ b/README.rst
@@ -200,8 +200,28 @@ This send and receive happens multiple times following the TCP connection flow:
 UDP packets
 ~~~~~~~~~~~
 
-TLS handshake...
-----------------
+TLS handshake
+-------------
+* The client computer sends a ``Client hello`` message to the server with it TLS version,
+  list of cipher algorithms and compression methods available.
+
+* The server replies with a ``Server hello`` message to the client with the TLS version, cipher
+  and compression methods selected + the Server public certificate signed by a CA (Certificate Authority)
+  that also contains a public key.
+
+* The client verifies the server digital certificate and cipher a symetric cryptography key using an asymetric
+  cryptography algorithm, attaching the server public key and an encrypted message for verification purposes.
+
+* The server decrypts the key using its private key and decrypts the verification message with it, then replies
+  with the verification message decrypted and signed with its private key
+
+* The client confirm the server identity, cipher the agreed key and sends a ``finished`` message to the server,
+  attaching the encrypted agreed key.
+
+* The server sends a ``finished`` message to the client, encrypted with the agreed key.
+
+* From now on the TLS session communicates information encrypted with the agreed key
+
 
 TCP packets
 ~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -270,7 +270,7 @@ ones are Apache for Linux, and IIS for windows.
   in our case it will fall back to the index file, as "/" is the main file
   (some cases can override this, but this is the most common method).
 * The server will parse the file according to the handler, for example -
-  let's say that Google are running on PHP.
+  let's say that Google is running on PHP.
    * The server will use the PHP executable to interpret the index file,
      and catch the output.
    * The server will return the output, back on the same GET request

--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,16 @@ this queue by threads with sufficient privileges calling the
 handled by, an ``NSApplication`` main event loop, via an ``NSEvent`` of
 ``NSEventType`` ``KeyDown``.
 
+(On GNU/Linux) the Xorg server listen for keycodes
+--------------------------------------------------
+
+When a graphical ``X server`` is used, a re-mapping of keycodes to scancodes
+is made with ``X server`` specific keymaps and rules.
+When the scancode mapping of the key pressed is complete, the ``X server``
+sends the character to the ``window manager`` (DWM, metacity, i3, etc), so the
+``window manager`` in turn sends the character to the focused window.
+The graphical API of the window  that receives the character prints the appropiate
+font symbol in the appropiate focused field.
 
 Is it a URL or a search term?
 -----------------------------

--- a/README.rst
+++ b/README.rst
@@ -209,9 +209,8 @@ Convert non-ASCII Unicode characters in hostname
 DNS lookup
 ----------
 
-* Browser checks if the domain is in its cache.
-  (to see DNS Cache list of Chrome browser, go to chrome://net-internals/#dns
-  in Chrome Browser).
+* Browser checks if the domain is in its cache. (to see DNS Cache in Chrome, go
+  to `chrome://net-internals/#dns <chrome://net-internals/#dns>`_).
 * If not found, the browser calls ``gethostbyname`` library function (varies by
   OS) to do the lookup.
 * ``gethostbyname`` checks if the hostname can be resolved by reference in the

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,9 @@ request, please!
 
 This is all licensed under the terms of the `Creative Commons Zero`_ license.
 
-Read this in `简体中文`_ (simplified Chinese), `日本語`_ (Japanese) and `한국어`_ (Korean). NOTE: these
-have not been reviewed by the alex/what-happens-when maintainers.
+Read this in `简体中文`_ (simplified Chinese), `日本語`_ (Japanese) and `한국어`_
+(Korean). NOTE: these have not been reviewed by the alex/what-happens-when
+maintainers.
 
 Table of Contents
 ====================

--- a/README.rst
+++ b/README.rst
@@ -491,7 +491,7 @@ to the browser it undergoes the below process:
 Browser
 -------
 
-The browser functionality is to present the web resource you choose, by
+The browser's functionality is to present the web resource you choose, by
 requesting it from the server and displaying it in the browser window.
 The resource is usually an HTML document, but may also be a PDF,
 image, or some other type of content. The location of the resource is

--- a/README.rst
+++ b/README.rst
@@ -364,7 +364,7 @@ TLS handshake
 * The client verifies the server digital certificate against its list of
   trusted CAs. If trust can be established based on the CA, the client
   generates a string of pseudo-random bytes and encrypts this with the server's
-  public key. These random bytes can be used determine the symmetric key.
+  public key. These random bytes can be used to determine the symmetric key.
 
 * The server decrypts the random bytes using its private key and uses these
   bytes to generate its own copy of the symmetric master key.

--- a/README.rst
+++ b/README.rst
@@ -61,19 +61,20 @@ connection, but historically has been over PS/2 or ADB connections.
 
 - In modern capacitive touch screens when the user puts his finger on the
   screen a tiny amount of current from the electrostatic field of the
-  conductive layer gets transferred to the finger completing the circuit,
-  creating a voltage dropping at that point on the screen that the
-  ``screen controller`` which rises an interrupt reporting the coordinate of
+  conductive layer gets transferred to the finger completing the circuit
+  and creating a voltage dropping at that point on the screen so that the
+  ``screen controller`` raises an interrupt reporting the coordinate of
   the 'click'.
 
-- Then the mobile OS notify the current focused application of a click event in
-  one of its GUI elements (which now is the virtual keyboard application
+- Then the mobile OS notifies the current focused application of a click event
+  in one of its GUI elements (which now is the virtual keyboard application
   buttons).
 
-- The virtual keyboard can now rises a software interrupt for sending a
+- The virtual keyboard can now raises a software interrupt for sending a
   'key pressed' message back to the OS.
 
-- Which in turn notify the current focused application of a 'key pressed' event
+- Which in turn notifies the current focused application of a 'key pressed'
+  event.
 
 
 Interrupt fires [NOT for USB keyboards]

--- a/README.rst
+++ b/README.rst
@@ -166,7 +166,7 @@ Is it a URL or a search term?
 
 When no protocol or valid domain name is given the browser proceeds to feed
 the text given in the address box to the browser's default web search engine.
-In many cases the url has a special peice of text appended to it to tell the
+In many cases the url has a special piece of text appended to it to tell the
 search engine that it came from a particular browser's url bar.
 
 

--- a/README.rst
+++ b/README.rst
@@ -363,10 +363,10 @@ UDP packets
 
 TLS handshake
 -------------
-* The client computer sends a ``Client hello`` message to the server with it
+* The client computer sends a ``ClientHello`` message to the server with its
   TLS version, list of cipher algorithms and compression methods available.
 
-* The server replies with a ``Server hello`` message to the client with the
+* The server replies with a ``ServerHello`` message to the client with the
   TLS version, selected cipher, selected compression methods and the server's
   public certificate signed by a CA (Certificate Authority). The certificate
   contains a public key that will be used by the client to encrypt the rest of

--- a/README.rst
+++ b/README.rst
@@ -397,6 +397,23 @@ TLS handshake
 * From now on the TLS session transmits the application (HTTP) data encrypted
   with the agreed symmetric key.
 
+If a packet is dropped
+----------------------
+
+Sometimes, due to network congestion or flaky hardware connections, TLS packets
+will be dropped before they get to their final destination. The sender then has
+to decide how to react. The algorithm for this is called `TCP congestion
+control`_. This varies depending on the sender; the most common algorithms are
+`cubic`_ on newer operating systems and `New Reno`_ on almost all others.
+
+* Client chooses a `congestion window`_ based on the `maximum segment size`_
+  (MSS) of the connection.
+* For each packet acknowledged, the window doubles in size until it reaches the
+  'slow-start threshold'. In some implementations, this threshold is adaptive.
+* After reaching the slow start threshold, the window increases additively for
+  each packet acknowledged. If a packet is dropped, the window reduces
+  exponentially until another packet is acknowledged.
+
 HTTP protocol
 -------------
 
@@ -680,6 +697,11 @@ page rendering and painting.
 .. _`Cellular data network`: https://en.wikipedia.org/wiki/Cellular_data_communication_protocol
 .. _`analog-to-digital converter`: https://en.wikipedia.org/wiki/Analog-to-digital_converter
 .. _`network node`: https://en.wikipedia.org/wiki/Computer_network#Network_nodes
+.. _`TCP congestion control`: https://en.wikipedia.org/wiki/TCP_congestion_control
+.. _`cubic`: https://en.wikipedia.org/wiki/CUBIC_TCP
+.. _`New Reno`: https://en.wikipedia.org/wiki/TCP_congestion_control#TCP_New_Reno
+.. _`congestion window`: https://en.wikipedia.org/wiki/TCP_congestion_control#Congestion_window
+.. _`maximum segment size`: https://en.wikipedia.org/wiki/Maximum_segment_size
 .. _`varies by OS` : https://en.wikipedia.org/wiki/Hosts_%28file%29#Location_in_the_file_system
 .. _`简体中文`: https://github.com/skyline75489/what-happens-when-zh_CN
 .. _`한국어`: https://github.com/SantonyChoi/what-happens-when-KR

--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ Parse URL...
 ------------
 
 Check HOSTS list...
-------------------
+-------------------
 
 Convert non-ASCII Unicode characters in hostname
 ------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -476,6 +476,61 @@ The most common HTTPD servers are Apache for Linux, and IIS for windows.
 * The server will use PHP to interpret the index file, and catch the output.
 * The server will return the output, on the same request to the client.
 
+Behind the scenes of Browser
+----------------------------------
+
+Once the server supplies the resources (HTML, CSS, JS, Image, etc.,)
+to browser it undergoes the below process
+
+* Parsing - HTML, CSS, JS
+* Rendering - Construct DOM Tree → Render Tree → Layout of Render Tree →
+Painting the render tree
+
+Browser
+-------
+
+The browser functionality is to present the web resource you choose, by
+requesting it from the server and displaying it in the browser window.
+The resource is usually an HTML document, but may also be a PDF,
+image, or some other type of content. The location of the resource is
+specified by the user using a URI (Uniform Resource Identifier).
+
+The way the browser interprets and displays HTML files is specified
+in the HTML and CSS specifications. These specifications are maintained
+by the W3C (World Wide Web Consortium) organization, which is the standards
+organization for the web.
+
+Browser user interfaces have a lot in common with each other. Among the
+common user interface elements are:
+
+* Address bar for inserting a URI
+* Back and forward buttons
+* Bookmarking options
+* Refresh and stop buttons for refreshing or stopping the loading of
+current documents
+* Home button that takes you to your home page
+
+** Browser High Level Structure **
+
+The components of the browsers are
+* **The user interface:** this includes the address bar, back/forward button,
+bookmarking menu, etc. Every part of the browser display except the window
+where you see the requested page.
+* **The browser engine:** marshals actions between the UI and the rendering
+engine.
+* **The rendering engine:** responsible for displaying requested content.
+For example if the requested content is HTML, the rendering engine parses
+HTML and CSS, and displays the parsed content on the screen.
+* **Networking:** for network calls such as HTTP requests, using different
+implementations for different platform behind a platform-independent interface.
+* **UI backend:** used for drawing basic widgets like combo boxes and windows.
+This backend exposes a generic interface that is not platform specific.
+Underneath it uses operating system user interface methods.
+* **JavaScript interpreter.** Used to parse and execute JavaScript code.
+* **Data storage.** This is a persistence layer. The browser may need to save
+all sorts of data locally, such as cookies. Browsers also support storage
+mechanisms such as localStorage, IndexedDB, WebSQL and FileSystem.
+
 HTML parsing
 ------------
 
@@ -516,7 +571,7 @@ set to "complete" and a "load" event will be fired.
 You can see the full algorithms for tokenization and tree construction
 in the HTML5 specification
 
-**Browsers' error tolerance**
+**Browsers error tolerance**
 
 You never get an "Invalid Syntax" error on an HTML page. Browsers fix
 any invalid content and go on.

--- a/README.rst
+++ b/README.rst
@@ -226,7 +226,7 @@ DNS lookup
 
 ARP process
 -----------
-In order to send an ARP broadcast the network stack library needs the target IP
+In order to send an ARP (Address Resolution Protocol) broadcast the network stack library needs the target IP
 address to look up. It also needs to know the MAC address of the interface it
 will use to send out the ARP broadcast.
 
@@ -242,7 +242,7 @@ If the entry is not in the ARP cache:
 
 * The MAC address of the selected network interface is looked up.
 
-* The network library sends a Layer 2 ARP request:
+* The network library sends a Layer 2 (data link layer of the `OSI model`_) ARP request:
 
 ``ARP Request``::
 
@@ -676,3 +676,4 @@ page rendering and painting.
 .. _`varies by OS` : https://en.wikipedia.org/wiki/Hosts_%28file%29#Location_in_the_file_system
 .. _`简体中文`: https://github.com/skyline75489/what-happens-when-zh_CN
 .. _`downgrade attack`: http://en.wikipedia.org/wiki/SSL_stripping
+.. _`OSI Model`: https://en.wikipedia.org/wiki/OSI_model

--- a/README.rst
+++ b/README.rst
@@ -26,14 +26,18 @@ Table of Contents
 
 The "g" key is pressed
 ----------------------
-The following sections explains all about the physical keyboard and the OS interrupts.
-But, a whole lot happens after that which isn't explained. When you just press "g" the
-browser receives the event and the entire auto-complete machinery kicks into high gear.
-Depending on your browser's algorithm and if you are in private/incognito mode or not
-various suggestions will be presented to you in the dropbox below the URL bar. Most of these algorithms prioritize results based on search history and bookmarks. Some
-browsers like Rockmelt even suggested your Facebook friends. You are going to
-type "google.com" so none of it matters, but a lot of code will run before you get
-there and the suggestions will be refined with each key press. It may even suggest "google.com" before you type it. 
+The following sections explains all about the physical keyboard
+and the OS interrupts. But, a whole lot happens after that which
+isn't explained. When you just press "g" the browser receives the
+event and the entire auto-complete machinery kicks into high gear.
+Depending on your browser's algorithm and if you are in 
+private/incognito mode or not various suggestions will be presented
+to you in the dropbox below the URL bar. Most of these algorithms 
+prioritize results based on search history and bookmarks. Some
+browsers like Rockmelt even suggested your Facebook friends. You are
+going to type "google.com" so none of it matters, but a lot of code
+will run before you get there and the suggestions will be refined
+with each key press. It may even suggest "google.com" before you type it.
 
 The "enter" key bottoms out
 ---------------------------

--- a/README.rst
+++ b/README.rst
@@ -226,9 +226,10 @@ DNS lookup
 
 ARP process
 -----------
-In order to send an ARP (Address Resolution Protocol) broadcast the network stack library needs the target IP
-address to look up. It also needs to know the MAC address of the interface it
-will use to send out the ARP broadcast.
+
+In order to send an ARP (Address Resolution Protocol) broadcast the network
+stack library needs the target IP address to look up. It also needs to know the
+MAC address of the interface it will use to send out the ARP broadcast.
 
 The ARP cache is first checked for an ARP entry for our target IP. If it is in
 the cache, the library function returns the result: Target IP = MAC.
@@ -242,7 +243,8 @@ If the entry is not in the ARP cache:
 
 * The MAC address of the selected network interface is looked up.
 
-* The network library sends a Layer 2 (data link layer of the `OSI model`_) ARP request:
+* The network library sends a Layer 2 (data link layer of the `OSI model`_)
+  ARP request:
 
 ``ARP Request``::
 

--- a/README.rst
+++ b/README.rst
@@ -420,7 +420,7 @@ the connection will be closed after completion of the response. For example,
     Connection: close
 
 HTTP/1.1 applications that do not support persistent connections MUST include
-the "close" connection option in every message. 
+the "close" connection option in every message.
 
 After sending the request and headers, the web browser sends a single blank
 newline to the server indicating that the content of the request is done.

--- a/README.rst
+++ b/README.rst
@@ -510,9 +510,10 @@ common user interface elements are:
   current documents
 * Home button that takes you to your home page
 
-** Browser High Level Structure **
+**Browser High Level Structure**
 
 The components of the browsers are
+
 * **The user interface:** this includes the address bar, back/forward button,
   bookmarking menu, etc. Every part of the browser display except the window
   where you see the requested page.

--- a/README.rst
+++ b/README.rst
@@ -479,6 +479,9 @@ The most common HTTPD servers are Apache for Linux, and IIS for windows.
 HTML parsing
 ------------
 
+The rendering engine will start getting the contents of the requested
+document from the networking layer. This will usually be done in 8kB chunks.
+
 The primary job of HTML parser to parse the HTML markup into a parse tree.
 
 The output tree (the "parse tree") is a tree of DOM element and attribute
@@ -520,6 +523,11 @@ in the HTML5 specification
 
 You never get an "Invalid Syntax" error on an HTML page. Browsers fix
 any invalid content and go on.
+
+Fetch/prefetch external resources linked to the page (CSS, Images, JavaScript
+files, etc.)
+
+Execute synchronous JavaScript code.
 
 CSS interpretation
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -604,7 +604,7 @@ Execute synchronous JavaScript code.
 CSS interpretation
 ------------------
 
-* Parse CSS files and ``<style>`` tag contents using `"CSS lexical and syntax
+* Parse CSS files, ``<style>`` tag contents, and ''style'' attribute values using `"CSS lexical and syntax
   grammar"`_
 * Each CSS file is parsed into a ``StyleSheet object``, where each object
   contains CSS rules with selectors and objects corresponding CSS grammar.

--- a/README.rst
+++ b/README.rst
@@ -604,8 +604,8 @@ Execute synchronous JavaScript code.
 CSS interpretation
 ------------------
 
-* Parse CSS files, ``<style>`` tag contents, and ''style'' attribute values using `"CSS lexical and syntax
-  grammar"`_
+* Parse CSS files, ``<style>`` tag contents, and ''style'' attribute 
+  values using `"CSS lexical and syntax grammar"`_
 * Each CSS file is parsed into a ``StyleSheet object``, where each object
   contains CSS rules with selectors and objects corresponding CSS grammar.
 * A CSS parser can be top-down or bottom-up when a specific parser generator

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ and the OS interrupts. When you press the key "g" the browser receives the
 event and the auto-complete functions kick in.
 Depending on your browser's algorithm and if you are in
 private/incognito mode or not various suggestions will be presented
-to you in the dropbox below the URL bar. Most of these algorithms sort
+to you in the dropdown below the URL bar. Most of these algorithms sort
 and prioritize results based on search history, bookmarks, cookies, and
 popular searches from the internet as a whole. As you are typing
 "google.com" many blocks of code run and the suggestions will be refined

--- a/README.rst
+++ b/README.rst
@@ -402,6 +402,7 @@ request to the server of the form::
 
     GET / HTTP/1.1
     Host: google.com
+	Connection: close
     [other headers]
 
 where ``[other headers]`` refers to a series of colon-separated key-value pairs
@@ -410,6 +411,14 @@ formatted as per the HTTP specification and separated by single new lines.
 HTTP spec. This also assumes that the web browser is using ``HTTP/1.1``,
 otherwise it may not include the ``Host`` header in the request and the version
 specified in the ``GET`` request will either be ``HTTP/1.0`` or ``HTTP/0.9``.)
+
+HTTP/1.1 defines the "close" connection option for the sender to signal that
+the connection will be closed after completion of the response. For example,
+
+    Connection: close
+
+HTTP/1.1 applications that do not support persistent connections MUST include
+the "close" connection option in every message. 
 
 After sending the request and headers, the web browser sends a single blank
 newline to the server indicating that the content of the request is done.

--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ enter?"
 Except instead of the usual story, we're going to try to answer this question
 in as much detail as possible. No skipping out on anything.
 
-This is a collaborative process, so dig in and try to help out! There are tons of
-details missing, just waiting for you to add them! So send us a pull request,
+This is a collaborative process, so dig in and try to help out! There are tons
+of details missing, just waiting for you to add them! So send us a pull request,
 please!
 
 This is all licensed under the terms of the `Creative Commons Zero`_ license.

--- a/README.rst
+++ b/README.rst
@@ -404,7 +404,7 @@ request to the server of the form::
 
     GET / HTTP/1.1
     Host: google.com
-	Connection: close
+    Connection: close
     [other headers]
 
 where ``[other headers]`` refers to a series of colon-separated key-value pairs

--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,8 @@ connection, but historically has been over PS/2 or ADB connections.
 - This value goes to the USB SIE (Serial Interface Engine) to be converted in
   one or more USB packets that follows the low level USB protocol.
 
-- Those packets are sent by a differential electrical signal over D+ and D- pins
-  (the middle 2) at a maximum speed of 1.5 Mb/s, as an HID
+- Those packets are sent by a differential electrical signal over D+ and D-
+  pins (the middle 2) at a maximum speed of 1.5 Mb/s, as an HID
   (Human Interface Device) device is always declared to be a "low speed device"
   (USB 2.0 compliance).
 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,8 @@ please!
 
 This is all licensed under the terms of the `Creative Commons Zero`_ license.
 
-Read this in `简体中文`_ .
+Read this in `简体中文`_ (simplified Chinese). NOTE: this has not been reviewed
+by the alex/what-happens-when maintainers.
 
 Table of Contents
 ====================

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@ please!
 
 This is all licensed under the terms of the `Creative Commons Zero`_ license.
 
-Read this in `简体中文`_ (simplified Chinese). NOTE: this has not been reviewed
-by the alex/what-happens-when maintainers.
+Read this in `简体中文`_ (simplified Chinese) and `한국어`_ (Korean). NOTE: these
+have not been reviewed by the alex/what-happens-when maintainers.
 
 Table of Contents
 ====================
@@ -680,5 +680,6 @@ page rendering and painting.
 .. _`network node`: https://en.wikipedia.org/wiki/Computer_network#Network_nodes
 .. _`varies by OS` : https://en.wikipedia.org/wiki/Hosts_%28file%29#Location_in_the_file_system
 .. _`简体中文`: https://github.com/skyline75489/what-happens-when-zh_CN
+.. _`한국어`: https://github.com/SantonyChoi/what-happens-when-KR
 .. _`downgrade attack`: http://en.wikipedia.org/wiki/SSL_stripping
 .. _`OSI Model`: https://en.wikipedia.org/wiki/OSI_model

--- a/README.rst
+++ b/README.rst
@@ -33,34 +33,47 @@ The keyboard controller then encodes the keycode for transport to the computer.
 This is now almost universally over a Universal Serial Bus (USB) or Bluetooth
 connection, but historically has been over PS/2 or ADB connections.
 
-In the case of the USB keyboard: The USB circuitry of the keyboard is powered
-by the 5V supply provided over pin 1 from the computer's USB host controller.
-The keycode generated is stored by internal keyboard circuitry memory in a
-register called "endpoint".
-The host USB contoller polls that "endpoint" every ~10ms (minimum value
-declared by the keyboard), so it gets the keycode value stored on it.
-This value goes to the USB SIE (Serial Interface Engine) to be converted in
-one or more USB packets that follows the low level USB protocol.
-Those packets are sent by a diferential electrical signal over D+ and D- pins
-(the middle 2) at a maximum speed of 1.5 Mb/s, as an HID
-(Human Interface Devide) device is always declared to be a "low speed device"
-(USB 2.0 compliance).
-This serial signal is then decoded at the computer's host USB controller, and
-interpreted by the computer's Human Interface Device (HID) universal keyboard
-device driver.  The value of the key is then passed into the operating system's
-hardware abstraction layer.
+*In the case of the USB keyboard:*
 
-In the case of Virtual Keyboard (as in touch screen devices): In modern
-capacitive touch screens when the user puts his finger on the screen a tiny
-amount of current from the electrostatic field of the conductive layer gets
-transferred to the finger completing the circuit, creating a voltage dropping
-at that point on the screen that the ``screen controller`` which rises an
-interrupt reporting the coordinate of the 'click'.
-Then the mobile OS notify the current focused application of a click event in
+- The USB circuitry of the keyboard is powered by the 5V supply provided over
+   pin 1 from the computer's USB host controller.
+
+- The keycode generated is stored by internal keyboard circuitry memory in a
+  register called "endpoint".
+
+- The host USB contoller polls that "endpoint" every ~10ms (minimum value
+  declared by the keyboard), so it gets the keycode value stored on it.
+
+- This value goes to the USB SIE (Serial Interface Engine) to be converted in
+  one or more USB packets that follows the low level USB protocol.
+
+- Those packets are sent by a diferential electrical signal over D+ and D- pins
+  (the middle 2) at a maximum speed of 1.5 Mb/s, as an HID
+  (Human Interface Devide) device is always declared to be a "low speed device"
+  (USB 2.0 compliance).
+
+- This serial signal is then decoded at the computer's host USB controller, and
+  interpreted by the computer's Human Interface Device (HID) universal keyboard
+  device driver.  The value of the key is then passed into the operating
+  system's hardware abstraction layer.
+
+*In the case of Virtual Keyboard (as in touch screen devices):*
+
+- In modern capacitive touch screens when the user puts his finger on the
+  screen a tiny amount of current from the electrostatic field of the
+  conductive layer gets transferred to the finger completing the circuit,
+  creating a voltage dropping at that point on the screen that the
+  ``screen controller`` which rises an interrupt reporting the coordinate of
+  the 'click'.
+
+- Then the mobile OS notify the current focused application of a click event in
 one of its GUI elements (which now is the virtual keyboard application buttons)
-The virtual keyboard can now rises a software interrupt for sending a
-'key pressed' message back to the OS which in turn notify the current focused
-application of a 'key pressed' event.
+
+- The virtual keyboard can now rises a software interrupt for sending a
+  'key pressed' message back to the OS.
+
+- Which in turn notify the current focused application of a 'key pressed' event
+
 
 Interrupt fires [NOT for USB keyboards]
 ---------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ This value goes to the USB SIE (Serial Interface Engine) to be converted in
 one or more USB packets that follows the low level USB protocol.
 Those packets are sent by a diferential electrical signal over D+ and D- pins
 (the middle 2) at a maximum speed of 1.5 Mb/s, as an HID
-(Human Interface Devide) device is always declared to be a "low speed device"
+(Human Interface Device) device is always declared to be a "low speed device"
 (USB 2.0 compliance).
 This serial signal is then decoded at the computer's host USB controller, and
 interpreted by the computer's Human Interface Device (HID) universal keyboard
@@ -121,7 +121,7 @@ Is it a URL or a search term?
 Parse URL...
 ------------
 
-Check HSTS list...
+Check HOSTS list...
 ------------------
 
 Convert non-ASCII Unicode characters in hostname

--- a/README.rst
+++ b/README.rst
@@ -209,8 +209,8 @@ Convert non-ASCII Unicode characters in hostname
 DNS lookup
 ----------
 
-* Browser checks if the domain is in its cache. (to see DNS Cache in Chrome, go
-  to `chrome://net-internals/#dns <chrome://net-internals/#dns>`_).
+* Browser checks if the domain is in its cache. (to see the DNS Cache in
+  Chrome, go to `chrome://net-internals/#dns <chrome://net-internals/#dns>`_).
 * If not found, the browser calls ``gethostbyname`` library function (varies by
   OS) to do the lookup.
 * ``gethostbyname`` checks if the hostname can be resolved by reference in the

--- a/README.rst
+++ b/README.rst
@@ -26,17 +26,16 @@ Table of Contents
 
 The "g" key is pressed
 ----------------------
-The following sections explains all about the physical keyboard
-and the OS interrupts. But, a whole lot happens after that which
-isn't explained. When you just press "g" the browser receives the
-event and the entire auto-complete machinery kicks into high gear.
+The following sections explains the physical keyboard actions
+and the OS interrupts. When you press the key "g" the browser receives the
+event and the auto-complete functions kick in.
 Depending on your browser's algorithm and if you are in
 private/incognito mode or not various suggestions will be presented
-to you in the dropbox below the URL bar. Most of these algorithms
-prioritize results based on search history and bookmarks. You are
-going to type "google.com" so none of it matters, but a lot of code
-will run before you get there and the suggestions will be refined
-with each key press. It may even suggest "google.com" before you type it.
+to you in the dropbox below the URL bar. Most of these algorithms sort
+and prioritize results based on search history, bookmarks, cookies, and
+popular searches from the internet as a whole. As you are typing
+"google.com" many blocks of code run and the suggestions will be refined
+with each key press. It may even suggest "google.com" before you finish typing it.
 
 The "enter" key bottoms out
 ---------------------------

--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ handled by, an ``NSApplication`` main event loop, via an ``NSEvent`` of
 ``NSEventType`` ``KeyDown``.
 
 (On GNU/Linux) the Xorg server listens for keycodes
---------------------------------------------------
+---------------------------------------------------
 
 When a graphical ``X server`` is used, a re-mapping of keycodes to scancodes
 is made with ``X server`` specific keymaps and rules.

--- a/README.rst
+++ b/README.rst
@@ -183,8 +183,9 @@ DNS lookup...
 * Browser checks if the domain is in its cache.
 * If not found, calls ``gethostbyname`` library function (varies by OS) to do
   the lookup.
-* ``gethostbyname`` checks if the hostname can be resolved by looking in the
-  ``/etc/hosts`` file, before trying to resolve the hostname through DNS.
+* ``gethostbyname`` checks if the hostname can be resolved by reference in the
+  local ``hosts`` file (whose location `varies by OS`_) before trying to
+  resolve the hostname through DNS.
 * If ``gethostbyname`` does not have it cached nor in the ``hosts`` file then a
   request is made to the known DNS server that was given to the network stack.
   This is typically the local router or the ISP's caching DNS server.
@@ -550,3 +551,4 @@ page rendering and painting.
 .. _`Cellular data network`: https://en.wikipedia.org/wiki/Cellular_data_communication_protocol
 .. _`analog-to-digital converter`: https://en.wikipedia.org/wiki/Analog-to-digital_converter
 .. _`network node`: https://en.wikipedia.org/wiki/Computer_network#Network_nodes
+.. _`varies by OS` : https://en.wikipedia.org/wiki/Hosts_%28file%29#Location_in_the_file_system

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Depending on your browser's algorithm and if you are in private/incognito mode o
 various suggestions will be presented to you in the dropbox below the URL bar. Some
 browsers like Rockmelt even suggested your Facebook friends. You are going to
 type "google.com" so none of it matters, but a lot of code will run before you get
-there and the suggestions will be refined with each key press.
+there and the suggestions will be refined with each key press. It may even suggest "google.com" before you type it.
 
 The "enter" key bottoms out
 ---------------------------

--- a/README.rst
+++ b/README.rst
@@ -541,7 +541,7 @@ The components of the browsers are:
   boxes and windows. This backend exposes a generic interface that is not
   platform specific.
   Underneath it uses operating system user interface methods.
-* **JavaScript interpreter:** The JavaScript interpreter is used to parse and
+* **JavaScript engine:** The JavaScript engine is used to parse and
   execute JavaScript code.
 * **Data storage:** The data storage is a persistence layer. The browser may
   need to save all sorts of data locally, such as cookies. Browsers also

--- a/README.rst
+++ b/README.rst
@@ -152,12 +152,6 @@ Parse URL
     - ``Protocol``  "http"
         Use 'Hyper Text Transfer Protocol'
 
-    - ``Domain name``  "www.google.com"
-        Connect to host 'www.google.com'
-
-    - ``Web service type``  ".com"
-        The domain corresponds to a 'Commercial' web service
-
     - ``Resource``  "/"
         Retrieve main (index) page
 

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@ request, please!
 
 This is all licensed under the terms of the `Creative Commons Zero`_ license.
 
-Read this in `简体中文`_ (simplified Chinese), `日本語`_ (Japanese) and `한국어`_
-(Korean). NOTE: these have not been reviewed by the alex/what-happens-when
+Read this in `简体中文`_ (simplified Chinese), `日本語`_ (Japanese), `한국어`_
+(Korean) and `Spanish`_. NOTE: these have not been reviewed by the alex/what-happens-when
 maintainers.
 
 Table of Contents
@@ -708,3 +708,4 @@ page rendering and painting.
 .. _`日本語`: https://github.com/tettttsuo/what-happens-when-JA
 .. _`downgrade attack`: http://en.wikipedia.org/wiki/SSL_stripping
 .. _`OSI Model`: https://en.wikipedia.org/wiki/OSI_model
+.. _`Spanish`: https://github.com/gonzaleztroyano/what-happens-when-ES

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,13 @@ please!
 
 This is all licensed under the terms of the `Creative Commons Zero`_ license.
 
+Table of Contents
+====================
+
+.. contents::
+   :backlinks: none
+   :local:
+
 The "enter" key bottoms out
 ---------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,15 @@ the text given in the address box to the browser's default web search engine.
 In many cases the url has a special piece of text appended to it to tell the
 search engine that it came from a particular browser's url bar.
 
+Convert non-ASCII Unicode characters in hostname
+------------------------------------------------
+
+* The browser checks the hostname for characters that are not in ``a-z``,
+  ``A-Z``, ``0-9``, ``-``, or ``.``.
+* Since the hostname is ``google.com`` there won't be any, but if there were
+  the browser would apply `Punycode`_ encoding to the hostname portion of the
+  URL.
+
 Check HSTS list
 ---------------
 * The browser checks its "preloaded HSTS (HTTP Strict Transport Security)"
@@ -195,16 +204,6 @@ Check HSTS list
   single HTTP request could potentially leave the user vulnerable to a
   `downgrade attack`_, which is why the HSTS list is included in modern web
   browsers.)
-
-
-Convert non-ASCII Unicode characters in hostname
-------------------------------------------------
-
-* The browser checks the hostname for characters that are not in ``a-z``,
-  ``A-Z``, ``0-9``, ``-``, or ``.``.
-* Since the hostname is ``google.com`` there won't be any, but if there were
-  the browser would apply `Punycode`_ encoding to the hostname portion of the
-  URL.
 
 DNS lookup
 ----------

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,8 @@ connection, but historically has been over PS/2 or ADB connections.
 - The virtual keyboard can now raise a software interrupt for sending a
   'key pressed' message back to the OS.
 
-- This interrupt notifies the current focused application of a 'key pressed' event.
+- This interrupt notifies the current focused application of a 'key pressed'
+  event.
 
 
 Interrupt fires [NOT for USB keyboards]
@@ -203,8 +204,8 @@ DNS lookup
   local ``hosts`` file (whose location `varies by OS`_) before trying to
   resolve the hostname through DNS.
 * If ``gethostbyname`` does not have it cached nor can find it in the ``hosts``
-  file then it makes a request to the DNS server configured in the network stack.
-  This is typically the local router or the ISP's caching DNS server.
+  file then it makes a request to the DNS server configured in the network
+  stack. This is typically the local router or the ISP's caching DNS server.
 * If the DNS server is on the same subnet the network library follows the
   ``ARP process`` below for the DNS server.
 * If the DNS server is on a different subnet, the network library follows
@@ -214,18 +215,18 @@ DNS lookup
 ARP process
 -----------
 In order to send an ARP broadcast the network stack lbirary needs the target IP
-address to look up. It also needs to know the MAC address of the interface it will
-use to send out the ARP broadcast.
+address to look up. It also needs to know the MAC address of the interface it
+will use to send out the ARP broadcast.
 
-The ARP cache is first checked for an ARP entry for our target IP. If it is in the
-cache, the library function returns the result: Target IP = MAC.
+The ARP cache is first checked for an ARP entry for our target IP. If it is in
+the cache, the library function returns the result: Target IP = MAC.
 
 If the entry is not in the ARP cache:
 
 * The route table is looked up, to see if the Target IP address is on any of
-  the subnets on the local route table. If it is, the library uses the interface
-  associated with that subnet. If it is not, the library uses the interface that has
-  the subnet of our default gateway.
+  the subnets on the local route table. If it is, the library uses the
+  interface associated with that subnet. If it is not, the library uses the
+  interface that has the subnet of our default gateway.
 
 * The MAC address of the selected network interface is looked up.
 
@@ -242,20 +243,21 @@ Depending on what type of hardware is between the computer and the router:
 
 Directly connected:
 
-* If the computer is directly connected to the router the router responds with an
-  ``ARP Reply`` (see below)
+* If the computer is directly connected to the router the router responds
+  with an ``ARP Reply`` (see below)
 
 Hub:
 
-* If the computer is connected to a hub the hub will broadcast the ARP request out all
-  other ports. If the router is connected on the same "wire" it will respond with an
-  ``ARP Reply`` (see below).
+* If the computer is connected to a hub the hub will broadcast the ARP
+  request out all other ports. If the router is connected on the same "wire"
+  it will respond with an ``ARP Reply`` (see below).
 
 Switch:
 
-* If the computer is connected to a switch the switch will check it's local CAM/MAC table
-  to see which port has the MAC address we are looking for. If the switch has no entry
-  for the MAC address it will rebroadcast the ARP request to all other ports.
+* If the computer is connected to a switch the switch will check it's local
+  CAM/MAC table to see which port has the MAC address we are looking for. If
+  the switch has no entry for the MAC address it will rebroadcast the ARP
+  request to all other ports.
 
 * If the switch has an entry in the MAC/CAM table it will send the ARP request
   to the port that has the MAC address we are looking for.
@@ -371,11 +373,11 @@ TLS handshake
   the transmission up to this point with the symmetric key.
 
 * The server generates its own hash, and then decrypts the client-sent hash
-  to verify that it matches. If it does, it sends its own ``Finished`` message to
-  the client, also encrypted with the symmetric key.
+  to verify that it matches. If it does, it sends its own ``Finished`` message
+  to the client, also encrypted with the symmetric key.
 
-* From now on the TLS session transmits the application (HTTP) data encrypted with
-  the agreed symmetric key.
+* From now on the TLS session transmits the application (HTTP) data encrypted
+  with the agreed symmetric key.
 
 HTTP protocol
 -------------

--- a/README.rst
+++ b/README.rst
@@ -650,7 +650,7 @@ of some timing mechanism (such as a Google Doodle animation) or user
 interaction (typing a query into the search box and receiving suggestions).
 Plugins such as Flash or Java may execute as well, although not at this time on
 the Google homepage. Scripts can cause additional network requests to be
-performed, as well as modify the page or its layout, affecting another round of
+performed, as well as modify the page or its layout, causing another round of
 page rendering and painting.
 
 .. _`Creative Commons Zero`: https://creativecommons.org/publicdomain/zero/1.0/

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ Except instead of the usual story, we're going to try to answer this question
 in as much detail as possible. No skipping out on anything.
 
 This is a collaborative process, so dig in and try to help out! There are tons
-of details missing, just waiting for you to add them! So send us a pull request,
-please!
+of details missing, just waiting for you to add them! So send us a pull
+request, please!
 
 This is all licensed under the terms of the `Creative Commons Zero`_ license.
 

--- a/README.rst
+++ b/README.rst
@@ -30,10 +30,10 @@ The following sections explains all about the physical keyboard and the OS inter
 But, a whole lot happens after that which isn't explained. When you just press "g" the
 browser receives the event and the entire auto-complete machinery kicks into high gear.
 Depending on your browser's algorithm and if you are in private/incognito mode or not
-various suggestions will be presented to you in the dropbox below the URL bar. Some
+various suggestions will be presented to you in the dropbox below the URL bar. Most of these algorithms prioritize results based on search history and bookmarks. Some
 browsers like Rockmelt even suggested your Facebook friends. You are going to
 type "google.com" so none of it matters, but a lot of code will run before you get
-there and the suggestions will be refined with each key press. It may even suggest "google.com" before you type it.
+there and the suggestions will be refined with each key press. It may even suggest "google.com" before you type it. 
 
 The "enter" key bottoms out
 ---------------------------
@@ -157,15 +157,6 @@ sends the character to the ``window manager`` (DWM, metacity, i3, etc), so the
 ``window manager`` in turn sends the character to the focused window.
 The graphical API of the window  that receives the character prints the
 appropriate font symbol in the appropriate focused field.
-
-
-Browser history/bookmark lookup
--------------------------------
-
-Most browsers start making autocompletion suggestions based on the characters
-already entered. So each character that arrives in the address field of the
-browser triggers an algorithm matching bookmarks and browse history items
-and a short suggestion list is rendered either inline or as a dropdown.
 
 Parse URL
 ---------

--- a/README.rst
+++ b/README.rst
@@ -497,8 +497,8 @@ specified by the user using a URI (Uniform Resource Identifier).
 
 The way the browser interprets and displays HTML files is specified
 in the HTML and CSS specifications. These specifications are maintained
-by the W3C (World Wide Web Consortium) organization, which is the standards
-organization for the web.
+by the W3C (World Wide Web Consortium) organization, which is the
+standards organization for the web.
 
 Browser user interfaces have a lot in common with each other. Among the
 common user interface elements are:
@@ -514,23 +514,26 @@ common user interface elements are:
 
 The components of the browsers are
 
-* **The user interface:** this includes the address bar, back/forward button,
-  bookmarking menu, etc. Every part of the browser display except the window
-  where you see the requested page.
+* **The user interface:** this includes the address bar, back/forward
+  button, bookmarking menu, etc. Every part of the browser display except
+  the window where you see the requested page.
 * **The browser engine:** marshals actions between the UI and the rendering
   engine.
 * **The rendering engine:** responsible for displaying requested content.
   For example if the requested content is HTML, the rendering engine parses
   HTML and CSS, and displays the parsed content on the screen.
 * **Networking:** for network calls such as HTTP requests, using different
-  implementations for different platform behind a platform-independent interface.
-* **UI backend:** used for drawing basic widgets like combo boxes and windows.
-  This backend exposes a generic interface that is not platform specific.
+  implementations for different platform behind a platform-independent
+  interface.
+* **UI backend:** used for drawing basic widgets like combo boxes
+  and windows. This backend exposes a generic interface that is not
+  platform specific.
   Underneath it uses operating system user interface methods.
 * **JavaScript interpreter.** Used to parse and execute JavaScript code.
-* **Data storage.** This is a persistence layer. The browser may need to save
-  all sorts of data locally, such as cookies. Browsers also support storage
-  mechanisms such as localStorage, IndexedDB, WebSQL and FileSystem.
+* **Data storage.** This is a persistence layer. The browser may need to
+  save all sorts of data locally, such as cookies. Browsers also support
+  storage mechanisms such as localStorage, IndexedDB, WebSQL and
+  FileSystem.
 
 HTML parsing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -121,8 +121,8 @@ Is it a URL or a search term?
 Parse URL...
 ------------
 
-Check HOSTS list...
--------------------
+Check HSTS list...
+------------------
 
 Convert non-ASCII Unicode characters in hostname
 ------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -173,8 +173,8 @@ Check HSTS list...
 * The browser checks its "preloaded HSTS (HTTP Strict Transport Security)"
   list. This is a list of websites that have requested to be contacted via
   HTTPS only.
-* If the website is in the list, the browser sends its request via HTTP instead
-  of HTTPS.  Else, the initial request is sent via HTTP.
+* If the website is in the list, the browser sends its request via HTTPS
+  instead of HTTP. Otherwise, the initial request is sent via HTTP.
 * (Note that a website can still use the HSTS policy *without* being in the
   HSTS list.  The first HTTP request to the website by a user will receive a
   response requesting that the user only send HTTPS requests.  However, this

--- a/README.rst
+++ b/README.rst
@@ -442,6 +442,10 @@ The most common HTTPD servers are Apache for Linux, and IIS for windows.
 * The server verifies that google.com can accept GET requests.
 * The server verifies that the client is allowed to use this method
   (by IP, authentication, etc.).
+* If the server has a rewrite module installed (like mod_rewrite for Apache or
+  URL Rewrite for IIS), it tries to match the request against one of the
+  configured rules. If a matching rule is found, the server uses that rule to
+  rewrite the request.
 * The server goes to pull the content that corresponds with the request,
   in our case it will fall back to the index file, as "/" is the main file
   (some cases can override this, but this is the most common method).

--- a/README.rst
+++ b/README.rst
@@ -118,8 +118,31 @@ appropiate font symbol in the appropiate focused field.
 Is it a URL or a search term?
 -----------------------------
 
-Parse URL...
-------------
+Parse URL
+---------
+
+* The browser knows what to do based on the iformation provided by the URL,
+  where:
+
+  *``http://www.google.com``*
+
+  - ``http://``
+    Tells the browser that it needs to communicate using the 'Hiper Text
+    Trasnfer Protocol' with the target machine.
+
+  - ``www``
+    Indicates the target machine for the 'google.com' domain, which for this
+    case 'www' indicates the WEB service.
+
+  - ``.google``
+    Indicates the domain for google, where the DNS look up takes place to
+    translate it into an IP adress.
+
+  - ``.com``
+    Is the domain suffix for 'Commercial'.
+
+
+
 
 Check HSTS list...
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -82,9 +82,9 @@ connection, but historically has been over PS/2 or ADB connections.
   circuit through the electrostatic field of the conductive layer and
   creates a voltage drop at that point on the screen. The
   ``screen controller`` then raises an interrupt reporting the coordinate of
-  the 'click'.
+  the key press.
 
-- Then the mobile OS notifies the current focused application of a click event
+- Then the mobile OS notifies the current focused application of a press event
   in one of its GUI elements (which now is the virtual keyboard application
   buttons).
 

--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,7 @@ event and the entire auto-complete machinery kicks into high gear.
 Depending on your browser's algorithm and if you are in
 private/incognito mode or not various suggestions will be presented
 to you in the dropbox below the URL bar. Most of these algorithms
-prioritize results based on search history and bookmarks. Some
-browsers like Rockmelt even suggested your Facebook friends. You are
+prioritize results based on search history and bookmarks. You are
 going to type "google.com" so none of it matters, but a lot of code
 will run before you get there and the suggestions will be refined
 with each key press. It may even suggest "google.com" before you type it.

--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,14 @@ The graphical API of the window  that receives the character prints the
 appropriate font symbol in the appropriate focused field.
 
 
+Browser history/bookmark lookup
+-------------------------------
+
+Most browsers start making autocompletion suggestions based on the characters
+already entered. So each character that arrives in the address field of the
+browser triggers an algorithm matching bookmarks and browse history items
+and a short suggestion list is rendered either inline or as a dropdown.
+
 Parse URL
 ---------
 
@@ -168,7 +176,6 @@ When no protocol or valid domain name is given the browser proceeds to feed
 the text given in the address box to the browser's default web search engine.
 In many cases the url has a special piece of text appended to it to tell the
 search engine that it came from a particular browser's url bar.
-
 
 Check HSTS list
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ But, a whole lot happens after that which isn't explained. When you just press "
 browser receives the event and the entire auto-complete machinery kicks into high gear.
 Depending on your browser's algorithm and if you are in private/incognito mode or not
 various suggestions will be presented to you in the dropbox below the URL bar. Some
-browsers like Rockmelt R.I.P even suggested your Facebook friends. You are going to
+browsers like Rockmelt even suggested your Facebook friends. You are going to
 type "google.com" so none of it matters, but a lot of code will run before you get
 there and the suggestions will be refined with each key press.
 

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ connection, but historically has been over PS/2 or ADB connections.
 
 *In the case of Virtual Keyboard (as in touch screen devices):*
 
-- In modern capacitive touch screens when the user puts his finger on the
+- In modern capacitive touch screens when the user puts their finger on the
   screen a tiny amount of current from the electrostatic field of the
   conductive layer gets transferred to the finger completing the circuit
   and creating a voltage dropping at that point on the screen so that the

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ The keyboard controller then encodes the keycode for transport to the computer.
 This is now almost universally over a Universal Serial Bus (USB) or Bluetooth
 connection, but historically has been over PS/2 or ADB connections.
 
-In the case of the USB keyboard: the USB circuitry of the keyboard is powered
+In the case of the USB keyboard: The USB circuitry of the keyboard is powered
 by the 5V supply provided over pin 1 from the computer's USB host controller.
 The keycode generated is stored by internal keyboard circuitry memory in a
 register called "endpoint".
@@ -49,6 +49,18 @@ This serial signal is then decoded at the computer's host USB controller, and
 interpreted by the computer's Human Interface Device (HID) universal keyboard
 device driver.  The value of the key is then passed into the operating system's
 hardware abstraction layer.
+
+In the case of Virtual Keyboard (as in touch screen devices): In modern
+capacitive touch screens when the user puts his finger on the screen a tiny
+amount of current from the electrostatic field of the conductive layer gets
+transferred to the finger completing the circuit, creating a voltage dropping
+at that point on the screen that the ``screen controller`` which rises an
+interrupt reporting the coordinate of the 'click'.
+Then the mobile OS notify the current focused application of a click event in
+one of its GUI elements (which now is the virtual keyboard application buttons)
+The virtual keyboard can now rises a software interrupt for sending a
+'key pressed' message back to the OS which in turn notify the current focused
+application of a 'key pressed' event.
 
 Interrupt fires [NOT for USB keyboards]
 ---------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -63,10 +63,10 @@ connection, but historically has been over PS/2 or ADB connections.
 
 *In the case of Virtual Keyboard (as in touch screen devices):*
 
-- When the user puts their finger on a modern capacitive touch screen, a 
-  tiny amount of current gets transferred to the finger. This completes the 
-  circuit through the electrostatic field of the conductive layer and 
-  creates a voltage drop at that point on the screen. The 
+- When the user puts their finger on a modern capacitive touch screen, a
+  tiny amount of current gets transferred to the finger. This completes the
+  circuit through the electrostatic field of the conductive layer and
+  creates a voltage drop at that point on the screen. The
   ``screen controller`` then raises an interrupt reporting the coordinate of
   the 'click'.
 

--- a/README.rst
+++ b/README.rst
@@ -334,12 +334,13 @@ or direct Ethernet connections in which case the data remains digital and
 is passed directly to the next `network node`_ for processing.
 
 Eventually, the packet will reach the router managing the local subnet. From
-there, it will continue to travel to the AS's border routers, other ASes, and
-finally to the destination server. Each router along the way extracts the
-destination address from the IP header and routes it to the appropriate next
-hop. The TTL field in the IP header is decremented by one for each router that
-passes. The packet will be dropped if the TTL field reaches zero or if the
-current router has no space in its queue (perhaps due to network congestion).
+there, it will continue to travel to the autonomous system's (AS) border
+routers, other ASes, and finally to the destination server. Each router along
+the way extracts the destination address from the IP header and routes it to
+the appropriate next hop. The time to live (TTL) field in the IP header is
+decremented by one for each router that passes. The packet will be dropped if
+the TTL field reaches zero or if the current router has no space in its queue
+(perhaps due to network congestion).
 
 This send and receive happens multiple times following the TCP connection flow:
 
@@ -367,7 +368,8 @@ This send and receive happens multiple times following the TCP connection flow:
 TLS handshake
 -------------
 * The client computer sends a ``ClientHello`` message to the server with its
-  TLS version, list of cipher algorithms and compression methods available.
+  Transport Layer Security (TLS) version, list of cipher algorithms and
+  compression methods available.
 
 * The server replies with a ``ServerHello`` message to the client with the
   TLS version, selected cipher, selected compression methods and the server's

--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,8 @@ handled by, an ``NSApplication`` main event loop, via an ``NSEvent`` of
 (On GNU/Linux) the Xorg server listen for keycodes
 --------------------------------------------------
 
-When a graphical ``X server`` is used, a re-mapping of keycodes to scancodes
+When a graphical ``X server`` is used, ``X`` will use the generic event
+driver ``evdev`` to acquire the keypress. A re-mapping of keycodes to scancodes
 is made with ``X server`` specific keymaps and rules.
 When the scancode mapping of the key pressed is complete, the ``X server``
 sends the character to the ``window manager`` (DWM, metacity, i3, etc), so the

--- a/README.rst
+++ b/README.rst
@@ -516,26 +516,26 @@ common user interface elements are:
 
 The components of the browsers are
 
-* **User interface:** The user interface includes the address bar, 
-  back/forward button, bookmarking menu, etc. Every part of the browser 
+* **User interface:** The user interface includes the address bar,
+  back/forward button, bookmarking menu, etc. Every part of the browser
   display except the window where you see the requested page.
 * **Browser engine:** The browser engine marshals actions between the UI
   and the rendering engine.
 * **Rendering engine:** The rendering engine is responsible for displaying
-  requested content. For example if the requested content is HTML, the 
-  rendering engine parses HTML and CSS, and displays the parsed content on 
+  requested content. For example if the requested content is HTML, the
+  rendering engine parses HTML and CSS, and displays the parsed content on
   the screen.
 * **Networking:** The networking handles network calls such as HTTP requests,
-  using different implementations for different platform behind a 
+  using different implementations for different platform behind a
   platform-independent interface.
-* **UI backend:** The UI backend is used for drawing basic widgets like combo 
+* **UI backend:** The UI backend is used for drawing basic widgets like combo
   boxes and windows. This backend exposes a generic interface that is not
   platform specific.
   Underneath it uses operating system user interface methods.
-* **JavaScript interpreter:** The JavaScript interpreter is used to parse and 
+* **JavaScript interpreter:** The JavaScript interpreter is used to parse and
   execute JavaScript code.
-* **Data storage:** The data storage is a persistence layer. The browser may 
-  need to save all sorts of data locally, such as cookies. Browsers also 
+* **Data storage:** The data storage is a persistence layer. The browser may
+  need to save all sorts of data locally, such as cookies. Browsers also
   support storage mechanisms such as localStorage, IndexedDB, WebSQL and
   FileSystem.
 

--- a/README.rst
+++ b/README.rst
@@ -28,15 +28,16 @@ connection, but historically has been over PS/2 or ADB connections.
 
 In the case of the USB keyboard: the USB circuitry of the keyboard is powered
 by the 5V supply provided over pin 1 from the computer's USB host controller.
-The keycode generated is stored by internal keyboard circuitry memory in a register
-called "endpoint".
-The host USB contoller polls that "endpoint" every ~10ms (minimum value declared by
-the keyboard), so it gets the keycode value stored on it.
-This value goes to the USB SIE (Serial Interface Engine) to be converted in one or 
-more USB packets that follows the low level USB protocol.
+The keycode generated is stored by internal keyboard circuitry memory in a
+register called "endpoint".
+The host USB contoller polls that "endpoint" every ~10ms (minimum value
+declared by the keyboard), so it gets the keycode value stored on it.
+This value goes to the USB SIE (Serial Interface Engine) to be converted in
+one or more USB packets that follows the low level USB protocol.
 Those packets are sent by a diferential electrical signal over D+ and D- pins
-(the middle 2) at a maximum speed of 1.5 Mb/s, as an HID  (Human Interface Devide)
-device is always declared to be a "low speed device" (USB 2.0 compliance).  
+(the middle 2) at a maximum speed of 1.5 Mb/s, as an HID
+(Human Interface Devide) device is always declared to be a "low speed device"
+(USB 2.0 compliance).
 This serial signal is then decoded at the computer's host USB controller, and
 interpreted by the computer's Human Interface Device (HID) universal keyboard
 device driver.  The value of the key is then passed into the operating system's
@@ -104,8 +105,8 @@ is made with ``X server`` specific keymaps and rules.
 When the scancode mapping of the key pressed is complete, the ``X server``
 sends the character to the ``window manager`` (DWM, metacity, i3, etc), so the
 ``window manager`` in turn sends the character to the focused window.
-The graphical API of the window  that receives the character prints the appropiate
-font symbol in the appropiate focused field.
+The graphical API of the window  that receives the character prints the
+appropiate font symbol in the appropiate focused field.
 
 Is it a URL or a search term?
 -----------------------------
@@ -202,25 +203,30 @@ UDP packets
 
 TLS handshake
 -------------
-* The client computer sends a ``Client hello`` message to the server with it TLS version,
-  list of cipher algorithms and compression methods available.
+* The client computer sends a ``Client hello`` message to the server with it
+  TLS version, list of cipher algorithms and compression methods available.
 
-* The server replies with a ``Server hello`` message to the client with the TLS version, cipher
-  and compression methods selected + the Server public certificate signed by a CA (Certificate Authority)
-  that also contains a public key.
+* The server replies with a ``Server hello`` message to the client with the
+  TLS version, cipher and compression methods selected + the Server public
+  certificate signed by a CA (Certificate Authority) that also contains a
+  public key.
 
-* The client verifies the server digital certificate and cipher a symetric cryptography key using an asymetric
-  cryptography algorithm, attaching the server public key and an encrypted message for verification purposes.
+* The client verifies the server digital certificate and cipher a symetric
+  cryptography key using an asymetric cryptography algorithm, attaching the
+  server public key and an encrypted message for verification purposes.
 
-* The server decrypts the key using its private key and decrypts the verification message with it, then replies
-  with the verification message decrypted and signed with its private key
+* The server decrypts the key using its private key and decrypts the
+  verification message with it, then replies with the verification message
+  decrypted and signed with its private key
 
-* The client confirm the server identity, cipher the agreed key and sends a ``finished`` message to the server,
-  attaching the encrypted agreed key.
+* The client confirm the server identity, cipher the agreed key and sends a
+  ``finished`` message to the server, attaching the encrypted agreed key.
 
-* The server sends a ``finished`` message to the client, encrypted with the agreed key.
+* The server sends a ``finished`` message to the client, encrypted with the
+  agreed key.
 
-* From now on the TLS session communicates information encrypted with the agreed key
+* From now on the TLS session communicates information encrypted with the
+  agreed key
 
 
 TCP packets

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,10 @@ connection, but historically has been over PS/2 or ADB connections.
 
 *In the case of Virtual Keyboard (as in touch screen devices):*
 
-- When the user puts their finger on a modern capacitive touch screen, a tiny amount of current gets transferred to the finger. This completes the circuit through the electrostatic field of the conductive layer and creates a voltage drop at that point on the screen. The
+- When the user puts their finger on a modern capacitive touch screen, a 
+  tiny amount of current gets transferred to the finger. This completes the 
+  circuit through the electrostatic field of the conductive layer and 
+  creates a voltage drop at that point on the screen. The 
   ``screen controller`` then raises an interrupt reporting the coordinate of
   the 'click'.
 

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ connection, but historically has been over PS/2 or ADB connections.
 *In the case of the USB keyboard:*
 
 - The USB circuitry of the keyboard is powered by the 5V supply provided over
-   pin 1 from the computer's USB host controller.
+  pin 1 from the computer's USB host controller.
 
 - The keycode generated is stored by internal keyboard circuitry memory in a
   register called "endpoint".
@@ -170,8 +170,8 @@ In many cases the url has a special piece of text appended to it to tell the
 search engine that it came from a particular browser's url bar.
 
 
-Check HSTS list...
-------------------
+Check HSTS list
+---------------
 * The browser checks its "preloaded HSTS (HTTP Strict Transport Security)"
   list. This is a list of websites that have requested to be contacted via
   HTTPS only.
@@ -194,8 +194,8 @@ Convert non-ASCII Unicode characters in hostname
   the browser would apply `Punycode`_ encoding to the hostname portion of the
   URL.
 
-DNS lookup...
--------------
+DNS lookup
+----------
 
 * Browser checks if the domain is in its cache.
 * If not found, calls ``gethostbyname`` library function (varies by OS) to do
@@ -292,8 +292,8 @@ we can resume our DNS process:
 Opening of a socket
 -------------------
 Once the browser receives the IP address of the destination server it takes
-that and the given port number from the URL (the http protocol defaults to port
-80, and https to port 443) and makes a call to the system library function
+that and the given port number from the URL (the HTTP protocol defaults to port
+80, and HTTPS to port 443) and makes a call to the system library function
 named ``socket`` and requests a TCP socket stream - ``AF_INET`` and
 ``SOCK_STREAM``.
 
@@ -371,29 +371,29 @@ TLS handshake
   certificate signed by a CA (Certificate Authority) that also contains a
   public key.
 
-* The client verifies the server digital certificate and cipher a symmetric
+* The client verifies the server digital certificate and ciphers a symmetric
   cryptography key using an asymmetric cryptography algorithm, attaching the
   server public key and an encrypted message for verification purposes.
 
 * The server decrypts the key using its private key and decrypts the
   verification message with it, then replies with the verification message
-  decrypted and signed with its private key
+  decrypted and signed with its private key.
 
-* The client confirm the server identity, cipher the agreed key and sends a
+* The client confirms the server identity, ciphers the agreed key and sends a
   ``finished`` message to the server, attaching the encrypted agreed key.
 
 * The server sends a ``finished`` message to the client, encrypted with the
   agreed key.
 
 * From now on the TLS session communicates information encrypted with the
-  agreed key
+  agreed key.
 
 
 TCP packets
 ~~~~~~~~~~~
 
-HTTP protocol...
-----------------
+HTTP protocol
+-------------
 
 If the web browser used was written by Google, instead of sending an HTTP
 request to retrieve the page, it will send a request to try and negotiate with
@@ -439,7 +439,7 @@ for further requests.
 If the HTTP headers sent by the web browser included sufficient information for
 the web server to determine if the version of the file cached by the web
 browser has been unmodified since the last retrieval (ie. if the web browser
-included an ``ETag`` header), it may have instead responded with a request of
+included an ``ETag`` header), it may have instead respond with a request of
 the form::
 
     304 Not Modified
@@ -482,9 +482,9 @@ The most common HTTPD servers are Apache for Linux, and IIS for windows.
 * The server goes to pull the content that corresponds with the request,
   in our case it will fall back to the index file, as "/" is the main file
   (some cases can override this, but this is the most common method).
-* The server will parse the file according to the handler, for example -
-  let's say that Google is running on PHP.
-* The server will use PHP to interpret the index file, and catch the output.
+* The server will parse the file according to the handler. For example, let's
+  say that Google is running on PHP. The server will use PHP to interpret the
+  index file, and catch the output.
 * The server will return the output, on the same request to the client.
 
 Behind the scenes of the Browser
@@ -523,7 +523,7 @@ common user interface elements are:
 
 **Browser High Level Structure**
 
-The components of the browsers are
+The components of the browsers are:
 
 * **User interface:** The user interface includes the address bar,
   back/forward button, bookmarking menu, etc. Every part of the browser
@@ -567,13 +567,14 @@ an almost one-to-one relation to the markup.
 HTML cannot be parsed using the regular top-down or bottom-up parsers.
 
 The reasons are:
+
 * The forgiving nature of the language.
 * The fact that browsers have traditional error tolerance to support well
-known cases of invalid HTML.
+  known cases of invalid HTML.
 * The parsing process is reentrant. For other languages, the source doesn't
-change during parsing, but in HTML, dynamic code (such as script elements
-containing `document.write()` calls) can add extra tokens, so the parsing
-process actually modifies the input.
+  change during parsing, but in HTML, dynamic code (such as script elements
+  containing `document.write()` calls) can add extra tokens, so the parsing
+  process actually modifies the input.
 
 Unable to use the regular parsing techniques, browsers create custom
 parsers for parsing HTML. The parsing algorithm is described in

--- a/README.rst
+++ b/README.rst
@@ -230,7 +230,7 @@ If the entry is not in the ARP cache:
 
 * The MAC address of the selected network interface is looked up.
 
-* The network library send a Layer 2 ARP request:
+* The network library sends a Layer 2 ARP request:
 
 ``ARP Request``::
 
@@ -248,13 +248,13 @@ Directly connected:
 
 Hub:
 
-* If the computer is connected to a hub the hub will broadcast the ARP
-  request out all other ports. If the router is connected on the same "wire"
+* If the computer is connected to a hub, the hub will broadcast the ARP
+  request out all other ports. If the router is connected on the same "wire",
   it will respond with an ``ARP Reply`` (see below).
 
 Switch:
 
-* If the computer is connected to a switch the switch will check it's local
+* If the computer is connected to a switch, the switch will check it's local
   CAM/MAC table to see which port has the MAC address we are looking for. If
   the switch has no entry for the MAC address it will rebroadcast the ARP
   request to all other ports.
@@ -262,7 +262,7 @@ Switch:
 * If the switch has an entry in the MAC/CAM table it will send the ARP request
   to the port that has the MAC address we are looking for.
 
-* If the router is on the same "wire" it will respond with an ``ARP Reply``
+* If the router is on the same "wire", it will respond with an ``ARP Reply``
   (see below)
 
 ``ARP Reply``::
@@ -283,9 +283,9 @@ the default gateway it can resume its DNS process:
 
 Opening of a socket
 -------------------
-Once the browser receives the IP address of the destination server it takes
+Once the browser receives the IP address of the destination server, it takes
 that and the given port number from the URL (the HTTP protocol defaults to port
-80, and HTTPS to port 443) and makes a call to the system library function
+80, and HTTPS to port 443), and makes a call to the system library function
 named ``socket`` and requests a TCP socket stream - ``AF_INET`` and
 ``SOCK_STREAM``.
 

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ please!
 
 This is all licensed under the terms of the `Creative Commons Zero`_ license.
 
+Read this in `简体中文`_ .
+
 Table of Contents
 ====================
 
@@ -552,3 +554,4 @@ page rendering and painting.
 .. _`analog-to-digital converter`: https://en.wikipedia.org/wiki/Analog-to-digital_converter
 .. _`network node`: https://en.wikipedia.org/wiki/Computer_network#Network_nodes
 .. _`varies by OS` : https://en.wikipedia.org/wiki/Hosts_%28file%29#Location_in_the_file_system
+.. _`简体中文`: https://github.com/skyline75489/what-happens-when-zh_CN

--- a/README.rst
+++ b/README.rst
@@ -248,6 +248,24 @@ resolving the other domain, and follow all steps up to this point for that
 domain. The ``Host`` header in the request will be set to the appropriate
 server name instead of ``google.com``.
 
+HTTP Server Request Handle
+--------------------------
+The HTTPD (HTTP Daemon) server is the one handling the requests/responses on the server side.
+The HTTPD server can be one of many servers out there, where the most common ones are Apache for Linux, and IIS for windows.
+
+* The HTTPD (HTTP Daemon) receives the request.
+* The server breaks down the request to the following parameters:
+   * HTTP Request Method (GET, POST, HEAD, PUT and DELETE), in our case - GET.
+   * Domain, in our case - google.com.
+   * Requested path/page, in our case - / (as no specific path/page was requested, / is the default path).
+* The server verifies that there is a Virtual Host configured on the server that corresponds with google.com.
+* The server verifies that google.com can accept GET requests.
+* The server verifies that the client is allowed to use this method (by IP, authentication, etc.).
+* The server goes to pull the content that corresponds with the request, in our case it will fall back to the index file, as "/" is the main file (some cases can override this, but this is the most common method).
+* The server will parse the file according to the handler, for example - let's say that Google are running on PHP.
+   * The server will use the PHP executable to interpret the index file, and catch the output.
+   * The server will return the output, back on the same GET request connection to the customer.
+
 HTML parsing...
 ---------------
 

--- a/README.rst
+++ b/README.rst
@@ -559,7 +559,7 @@ HTML parsing
 The rendering engine starts getting the contents of the requested
 document from the networking layer. This will usually be done in 8kB chunks.
 
-The primary job of HTML parser to parse the HTML markup into a parse tree.
+The primary job of HTML parser is to parse the HTML markup into a parse tree.
 
 The output tree (the "parse tree") is a tree of DOM element and attribute
 nodes. DOM is short for Document Object Model. It is the object presentation

--- a/README.rst
+++ b/README.rst
@@ -266,7 +266,7 @@ Hub:
 
 Switch:
 
-* If the computer is connected to a switch, the switch will check it's local
+* If the computer is connected to a switch, the switch will check its local
   CAM/MAC table to see which port has the MAC address we are looking for. If
   the switch has no entry for the MAC address it will rebroadcast the ARP
   request to all other ports.

--- a/README.rst
+++ b/README.rst
@@ -142,33 +142,31 @@ sends the character to the ``window manager`` (DWM, metacity, i3, etc), so the
 The graphical API of the window  that receives the character prints the
 appropiate font symbol in the appropiate focused field.
 
-Is it a URL or a search term?
------------------------------
 
 Parse URL
 ---------
 
-* The browser knows what to do based on the information provided by the URL,
-  where:
+* The browser has now the following information contained in the URL (Uniform
+  Resource Locator):
 
-  *``http://www.google.com``*
+    - ``Protocol``  "http"
+        Use 'Hyper Text Transfer Protocol'
 
-  - ``http://``
-    Tells the browser that it needs to communicate using the 'Hyper Text
-    Trasnfer Protocol' with the target machine.
+    - ``Domain name``  "www.google.com"
+        Connect to host 'www.google.com'
 
-  - ``www``
-    Indicates the target machine for the 'google.com' domain, which for this
-    case 'www' indicates the WEB service.
+    - ``Web service type``  ".com"
+        The domain corresponds to a 'Commercial' web service
 
-  - ``.google``
-    Indicates the domain for google, where the DNS look up takes place to
-    translate it into an IP adress.
-
-  - ``.com``
-    Is the domain suffix for 'Commercial'.
+    - ``Resource``  "/"
+        Retrieve main (index) page
 
 
+Is it a URL or a search term?
+-----------------------------
+
+When no protocol or valid domain name is given the browser proceeds to feed
+the text given in the URL bar to its default web search engine.
 
 
 Check HSTS list...

--- a/README.rst
+++ b/README.rst
@@ -479,14 +479,32 @@ The most common HTTPD servers are Apache for Linux, and IIS for windows.
 HTML parsing
 ------------
 
-* Fetch contents of requested document from network layer in 8kb chunks.
-* Parse HTML document (See
-  https://html.spec.whatwg.org/multipage/syntax.html#parsing for more
-  information).
-* Convert elements to DOM nodes in the content tree.
-* Fetch/prefetch external resources linked to the page (CSS, Images, JavaScript
-  files, etc.)
-* Execute synchronous JavaScript code.
+The primary job of HTML parser to parse the HTML markup into a parse tree.
+
+The output tree (the "parse tree") is a tree of DOM element and attribute nodes. DOM is short for Document Object Model. It is the object presentation of the HTML document and the interface of HTML elements to the outside world like JavaScript. The root of the tree is the "Document" object. The DOM has an almost one-to-one relation to the markup.
+
+**The parsing algorithm**
+
+HTML cannot be parsed using the regular top down or bottom up parsers.
+
+The reasons are:
+* The forgiving nature of the language.
+* The fact that browsers have traditional error tolerance to support well known cases of invalid HTML.
+* The parsing process is reentrant. For other languages, the source doesn't change during parsing, but in HTML, dynamic code (such as script elements containing `document.write()` calls) can add extra tokens, so the parsing process actually modifies the input.
+
+Unable to use the regular parsing techniques, browsers create custom parsers for parsing HTML. The parsing algorithm is described in detail by the HTML5 specification.
+
+The algorithm consists of two stages: tokenization and tree construction.
+
+**Actions when the parsing is finished**
+
+At this stage the browser will mark the document as interactive and start parsing scripts that are in "deferred" mode: those that should be executed after the document is parsed. The document state will be then set to "complete" and a "load" event will be fired.
+
+You can see the full algorithms for tokenization and tree construction in the HTML5 specification
+
+**Browsers' error tolerance**
+
+You never get an "Invalid Syntax" error on an HTML page. Browsers fix any invalid content and go on.
 
 CSS interpretation
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -650,7 +650,7 @@ of some timing mechanism (such as a Google Doodle animation) or user
 interaction (typing a query into the search box and receiving suggestions).
 Plugins such as Flash or Java may execute as well, although not at this time on
 the Google homepage. Scripts can cause additional network requests to be
-performed, as well as modify the page or its layout, effecting another round of
+performed, as well as modify the page or its layout, affecting another round of
 page rendering and painting.
 
 .. _`Creative Commons Zero`: https://creativecommons.org/publicdomain/zero/1.0/

--- a/README.rst
+++ b/README.rst
@@ -604,7 +604,7 @@ Execute synchronous JavaScript code.
 CSS interpretation
 ------------------
 
-* Parse CSS files, ``<style>`` tag contents, and ''style'' attribute
+* Parse CSS files, ``<style>`` tag contents, and ``style`` attribute
   values using `"CSS lexical and syntax grammar"`_
 * Each CSS file is parsed into a ``StyleSheet object``, where each object
   contains CSS rules with selectors and objects corresponding CSS grammar.

--- a/README.rst
+++ b/README.rst
@@ -467,9 +467,9 @@ and IIS for Windows.
 
 * The HTTPD (HTTP Daemon) receives the request.
 * The server breaks down the request to the following parameters:
-   * HTTP Request Method (either GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS
-     and TRACE). In the case of a URL entered directly into the address bar,
-     this will be GET.
+   * HTTP Request Method (either ``GET``, ``HEAD``, ``POST``, ``PUT``,
+     ``DELETE``, ``CONNECT``, ``OPTIONS``, or ``TRACE``). In the case of a URL
+     entered directly into the address bar, this will be ``GET``.
    * Domain, in this case - google.com.
    * Requested path/page, in this case - / (as no specific path/page was
      requested, / is the default path).

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,8 @@ What happens when...
 ====================
 
 This repository is an attempt to answer the age old interview question "What
-happens when you type google.com into your browser's address box and press enter?"
+happens when you type google.com into your browser's address box and press
+enter?"
 
 Except instead of the usual story, we're going to try to answer this question
 in as much detail as possible. No skipping out on anything.


### PR DESCRIPTION
`ARP process`` below for the DNS server.
* If the DNS server is on a different subnet, the network library follows
  the ``ARP process`` below for the default gateway IP.
 * DNS clients and DNS server both use caching to speed up the domain name lookup process and to ease traffic on the root servers.
* A cache is a temporary store
* If a client queries domain server A looking to resolve www.google.com, and in turn domain server A queries domain server B etc then the result will be stored in a     cache on
* the client ( windows only)
* domain server A
* domain server B
* If another client needs to resolve the same domain name using server A then server A can respond using the cached result.
* You can check the DNS cache on a Windows machine with the command:ipconfig /displaydns
* There are 4 different types of DNS servers involved when performing a DNS lookup. Each DNS server type has a different role to play and may not all be required under  certain circumstances.
* Recursive Resolver - This is the DNS server that your computer or device communicates with. This DNS server is typically issued to you automatically by your service provider and is geographically located nearby in order to return results as fast as possible. This server will cache DNS record data in order to speed up future DNS lookup requests.
* Root Nameserver - The root name server is responsible for returning the IP address of the TLD nameserver. For example, when resolving example.com, the root name server will return the IP address of the TLD name server responsible for .com domain names.
* TLD Nameserver - The Top Level Domain (TLD) name server is responsible for returning the authoritative name servers for all domains under the TLD it is responsible for. The .com TLD name server will return results for google.com but not example.org.
* Authoritative Nameserver - This is the DNS server for actually storing the DNS configuration data of a domain name.